### PR TITLE
Refactor compression interface

### DIFF
--- a/BisUtils.Core/Compression/BisLZOCompressionAlgorithms.cs
+++ b/BisUtils.Core/Compression/BisLZOCompressionAlgorithms.cs
@@ -4,10 +4,10 @@ using BisUtils.Core.Compression.Options;
 namespace BisUtils.Core.Compression; 
 
 public class BisLZOCompressionAlgorithms : IBisCompressionAlgorithm<BisLZOCompressionOptions>, IBisDecompressionAlgorithm<BisLZODecompressionOptions> {
-    public static long Compress(MemoryStream input, BinaryWriter output, BisLZOCompressionOptions options) 
-        => throw new NotSupportedException();
+    public long Compress(byte[] input, BinaryWriter output, BisLZOCompressionOptions options) 
+        => throw new NotImplementedException();
     
-    public static long Decompress(MemoryStream input, BinaryWriter output, BisLZODecompressionOptions options) {
+    public long Decompress(Stream input, BinaryWriter output, BisLZODecompressionOptions options) {
         var startPos = output.BaseStream.Position;
 
         var isCompressed = !(!options.ForceDecompression && input.Length > 1024);

--- a/BisUtils.Core/Compression/BisMiniLZOCompressionAlgorithms.cs
+++ b/BisUtils.Core/Compression/BisMiniLZOCompressionAlgorithms.cs
@@ -4,15 +4,17 @@ using BisUtils.Core.Compression.Options;
 namespace BisUtils.Core.Compression; 
 
 public class BisMiniLZOCompressionAlgorithms : IBisCompressionAlgorithm<BisCompressionOptions>, IBisDecompressionAlgorithm<BisDecompressionOptions> {
-    public static long Compress(MemoryStream input, BinaryWriter output, BisCompressionOptions options) {
+    public long Compress(byte[] input, BinaryWriter output, BisCompressionOptions options) {
         var startPos = output.BaseStream.Position;
-        output.Write(MiniLZO.Compress(input.ToArray()));
+        output.Write(MiniLZO.Compress(input));
         return output.BaseStream.Position - startPos;
     }
 
-    public static long Decompress(MemoryStream input, BinaryWriter output, BisDecompressionOptions options) {
+    public long Decompress(Stream input, BinaryWriter output, BisDecompressionOptions options) {
         var decompressed = new byte[options.ExpectedSize];
-        MiniLZO.Decompress(input.ToArray(), decompressed);
+        using var buffer = new MemoryStream();
+        input.CopyTo(buffer);
+        MiniLZO.Decompress(buffer.ToArray(), decompressed);
         output.Write(decompressed);
         return decompressed.Length;
     }

--- a/BisUtils.Core/Compression/BisZLibCompressionAlgorithms.cs
+++ b/BisUtils.Core/Compression/BisZLibCompressionAlgorithms.cs
@@ -4,10 +4,9 @@ using BisUtils.Core.Compression.Options;
 namespace BisUtils.Core.Compression; 
 
 public class BisZLibCompressionAlgorithms : IBisDecompressionAlgorithm<BisDecompressionOptions>, IBisCompressionAlgorithm<BisCompressionOptions> {
-    public static long Decompress(MemoryStream input, BinaryWriter output, BisDecompressionOptions options) {
+    public long Decompress(Stream input, BinaryWriter output, BisDecompressionOptions options) {
         var startPos = output.BaseStream.Position;
-        using var inputStream = new MemoryStream(input.ToArray());
-        var deflateStream = new DeflateStream(inputStream, CompressionMode.Decompress);
+        using var deflateStream = new DeflateStream(input, CompressionMode.Decompress, true);
         
         for ( var bytesRead = 0; bytesRead < options.ExpectedSize; ) {
             var toRead = 1000; // 1000 byte chunks
@@ -21,7 +20,5 @@ public class BisZLibCompressionAlgorithms : IBisDecompressionAlgorithm<BisDecomp
         return output.BaseStream.Position - startPos;
     }
 
-    public static long Compress(MemoryStream input, BinaryWriter output, BisCompressionOptions options) {
-        throw new NotSupportedException();
-    }
+    public long Compress(byte[] input, BinaryWriter output, BisCompressionOptions options) => throw new NotImplementedException();
 }

--- a/BisUtils.Core/Compression/IBisCompressionAlgorithm.cs
+++ b/BisUtils.Core/Compression/IBisCompressionAlgorithm.cs
@@ -10,7 +10,7 @@ public interface IBisDecompressionAlgorithm<T> where T : BisDecompressionOptions
     /// <param name="output">The output writer</param>
     /// <param name="options">Algorithm specific options used for decompression.</param>
     /// <returns>The amount of bytes written to the output stream.</returns>
-    static long Decompress(MemoryStream input, BinaryWriter output, T options) => throw new NotSupportedException();
+    long Decompress(Stream input, BinaryWriter output, T options) ;
 }
 
 public interface IBisCompressionAlgorithm<T> where T : BisCompressionOptions {
@@ -21,5 +21,5 @@ public interface IBisCompressionAlgorithm<T> where T : BisCompressionOptions {
     /// <param name="output"></param>
     /// <param name="options">Algorithm specific options used for compression.</param>
     /// <returns>The amount of bytes written to the output stream.</returns>
-    static long Compress(MemoryStream input, BinaryWriter output, T options) => throw new NotSupportedException();
+    long Compress(byte[] input, BinaryWriter output, T options);
 }

--- a/BisUtils.Core/Extensions/BinaryReaderExtensions.cs
+++ b/BisUtils.Core/Extensions/BinaryReaderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using BisUtils.Core.Compression;
 using BisUtils.Core.Compression.Options;
 using BisUtils.Core.Serialization;
 
@@ -61,15 +62,13 @@ namespace System.IO
 
         public static T ReadBinarized<T>(this BinaryReader reader) where T : IBisBinarizable, new() => (T) new T().ReadBinary(reader);
 
-        public static MemoryStream ReadCompressedData<T>(this BinaryReader reader, BisDecompressionOptions options) {
+        public static MemoryStream ReadCompressedData<T>(this BinaryReader reader, IBisDecompressionAlgorithm<T> decompression,
+            T options) where T: BisDecompressionOptions {
             var decompressedDataStream = new MemoryStream();
             var decompressedDataWriter = new BinaryWriter(decompressedDataStream, Encoding.UTF8);
 
-            typeof(T).GetMethod("Decompress")!.Invoke(null, new object[] {
-                new MemoryStream(reader.ReadBytes(options.ExpectedSize)),
-                decompressedDataWriter,
-                options
-            });
+            decompression.Decompress(new MemoryStream(reader.ReadBytes(options.ExpectedSize)),
+                decompressedDataWriter, options);
 
             return decompressedDataStream;
         }

--- a/BisUtils.Core/Extensions/BinaryWriterExtensions.cs
+++ b/BisUtils.Core/Extensions/BinaryWriterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using BisUtils.Core.Compression;
 using BisUtils.Core.Compression.Options;
 using BisUtils.Core.Serialization;
 
@@ -47,20 +48,10 @@ namespace System.IO
             var data = BitConverter.GetBytes(i);
             Array.Reverse(data);
             writer.Write(data);
-        } 
-        
-        
-        // I wish I didn't have to use reflection for this but alas,
-        //    .NET doesn't allow you to access static methods on generic types.
-        public static long WriteCompressedData<T>(this BinaryWriter writer, byte[] data,
-            BisCompressionOptions options) {
-            return (long) typeof(T).GetMethod("Compress")!.Invoke(null, new object[] {
-                new MemoryStream(data),
-                writer,
-                options
-            })!;
         }
-            
+
+        public static long WriteCompressedData<T>(this BinaryWriter writer, byte[] data,
+            IBisCompressionAlgorithm<T> compression, T options) where T : BisCompressionOptions => compression.Compress(data, writer, options);
+
     }
 }
-

--- a/BisUtils.PAK/PakFile.cs
+++ b/BisUtils.PAK/PakFile.cs
@@ -32,8 +32,9 @@ public class PakFile : BisSynchronizable, IPakEnumerable, IBisBinarizable {
         if (!decompress) goto ReturnDecompressed;
         if (fileEntry.CompressionType is PakCompressionType.ZLib) {
             try {
+                var decompression = new BisZLibCompressionAlgorithms();
                 using var decompressed =
-                    reader.ReadCompressedData<BisZLibCompressionAlgorithms>(new BisDecompressionOptions() {
+                    reader.ReadCompressedData(decompression, new BisDecompressionOptions() {
                             ExpectedSize = fileEntry.OriginalSize
                         }
                     );


### PR DESCRIPTION
## Changes:

* Implement algorithms in non-static classes to avoid using reflection in `BinaryReader/Writer` extension methods;
* Change `IBisCompressionAlgorithm.Compress` signature from `(MemoryStream input, BinaryWriter output, T options)` to `(byte[] input, BinaryWriter output, T options)`. 
  This change makes `Compress` more convenient for current use cases and avoids unnecessary convertson from an array to a stream and back. Other variants of `Compress` can be added as needed.
* Change `IBisDecompressionAlgorithm.Decompress` signature from `(MemoryStream input, BinaryWriter output, T options)` to `(Stream input, BinaryWriter output, T options)`.  `MemoryStream` looks like an unnecessary restriction on input, but I am not sure that `Stream` is better option. Maybe it should be `byte[]` for consistency?
* Update  `BinaryReader/Writer` extension methods.

Please note that I didn't change the use of compression in `BisUtils.PBO` to avoid merge conflicts with the `pbo` branch.

If you agree with the changes, I can also add additional extension methods for convenience, such as `ReadLzss`, `WriteLzo`, etc. and start writing tests for implementations.