### PR TITLE
Add benchmarks

### DIFF
--- a/BisUtils.sln
+++ b/BisUtils.sln
@@ -30,6 +30,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pre Processors", "Pre Proce
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BisUtils.PreProcessor.RV", "src\Pre Processors\BisUtils.PreProcessor.RV\BisUtils.PreProcessor.RV.csproj", "{44137427-4E99-4F20-829F-C7B40C6F0D36}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6685E7AA-0C0B-45E3-8CAC-1A0DDD407BD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BisUtils.Bank.Benchmarks", "test\BisUtils.Bank.Benchmarks\BisUtils.Bank.Benchmarks.csproj", "{E4ABA271-1B67-4C4F-8966-E14033AC6A57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +60,10 @@ Global
 		{44137427-4E99-4F20-829F-C7B40C6F0D36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44137427-4E99-4F20-829F-C7B40C6F0D36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44137427-4E99-4F20-829F-C7B40C6F0D36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4ABA271-1B67-4C4F-8966-E14033AC6A57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4ABA271-1B67-4C4F-8966-E14033AC6A57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4ABA271-1B67-4C4F-8966-E14033AC6A57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4ABA271-1B67-4C4F-8966-E14033AC6A57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,5 +81,6 @@ Global
 		{4FFCAE7B-C53D-46FD-B897-B21F86167CD5} = {9E3CD3FE-A652-47E7-B4D8-67B1287851CE}
 		{1362745F-B7FF-4405-9CB7-D9CDAFBA1555} = {9E3CD3FE-A652-47E7-B4D8-67B1287851CE}
 		{44137427-4E99-4F20-829F-C7B40C6F0D36} = {1362745F-B7FF-4405-9CB7-D9CDAFBA1555}
+		{E4ABA271-1B67-4C4F-8966-E14033AC6A57} = {6685E7AA-0C0B-45E3-8CAC-1A0DDD407BD1}
 	EndGlobalSection
 EndGlobal

--- a/src/BisUtils.Core/IO/BisBinaryWriter.cs
+++ b/src/BisUtils.Core/IO/BisBinaryWriter.cs
@@ -1,10 +1,22 @@
-﻿namespace BisUtils.Core.IO;
+namespace BisUtils.Core.IO;
 
 using System.Text;
 using Binarize.Options;
 
 public class BisBinaryWriter : BinaryWriter
 {
+    public BisBinaryWriter(Stream output) : base(output)
+    {
+    }
+
+    public BisBinaryWriter(Stream output, Encoding encoding) : base(output, encoding)
+    {
+    }
+
+    public BisBinaryWriter(Stream output, Encoding encoding, bool leaveOpen) : base(output, encoding, leaveOpen)
+    {
+    }
+
     public void WriteAsciiZ(string str, Encoding encoding)
     {
         var bytes = encoding.GetBytes(str);

--- a/src/File Formats/BisUtils.Bank/Model/Entry/PboDataEntry.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Entry/PboDataEntry.cs
@@ -1,4 +1,4 @@
-﻿namespace BisUtils.Bank.Model.Entry;
+namespace BisUtils.Bank.Model.Entry;
 
 using System.Diagnostics;
 using Alerts.Warnings;
@@ -48,9 +48,6 @@ public class PboDataEntry : PboEntry, IPboDataEntry
 
     public void ExpandDirectoryStructure()
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
         ArgumentNullException.ThrowIfNull(PboFile, "When expanding a Pbo Entry, The node must be established");
 
         var normalizePath = EntryName = PboPathUtilities.NormalizePboPath(EntryName);
@@ -64,19 +61,10 @@ public class PboDataEntry : PboEntry, IPboDataEntry
 
         ParentDirectory = PboFile.CreateDirectory(PboPathUtilities.GetParent(normalizePath), PboFile);
         ParentDirectory.PboEntries.Add(this);
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(ExpandDirectoryStructure) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
     }
 
     public sealed override Result Binarize(BisBinaryWriter writer, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = base.Binarize(writer, options);
         writer.Write((long)EntryMime);
         writer.Write(OriginalSize);
@@ -84,18 +72,11 @@ public class PboDataEntry : PboEntry, IPboDataEntry
         writer.Write(TimeStamp);
         writer.Write(DataSize);
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDataEntry::Binarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
         return LastResult;
     }
 
     public sealed override Result Validate(PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
         LastResult = Result.Ok();
 
         switch (EntryMime)
@@ -151,21 +132,11 @@ public class PboDataEntry : PboEntry, IPboDataEntry
             });
         }
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDataEntry::Validate) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
         return LastResult;
     }
 
     public sealed override Result Debinarize(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
-
         LastResult = base.Debinarize(reader, options);
         EntryMime = (PboEntryMime)reader.ReadInt32(); // TODO WARN/ERROR then recover
         OriginalSize = reader.ReadInt32();
@@ -177,12 +148,6 @@ public class PboDataEntry : PboEntry, IPboDataEntry
         {
             LastResult = Result.Merge(LastResult, Validate(options));
         }
-
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDataEntry::Validate) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult;
     }

--- a/src/File Formats/BisUtils.Bank/Model/Entry/PboVersionEntry.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Entry/PboVersionEntry.cs
@@ -1,4 +1,4 @@
-﻿namespace BisUtils.Bank.Model.Entry;
+namespace BisUtils.Bank.Model.Entry;
 
 using System.Diagnostics;
 using Alerts.Errors;
@@ -12,7 +12,6 @@ using FResults;
 using FResults.Extensions;
 using Options;
 using Stubs;
-using Utils;
 
 public interface IPboVersionEntry : IPboEntry, IFamilyParent, IBisCloneable<IPboVersionEntry>
 {
@@ -54,10 +53,6 @@ public class PboVersionEntry : PboEntry, IPboVersionEntry
 
     public Result ReadPboProperties(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         var results = new List<Result>();
         var property = new PboProperty(PboFile, this, string.Empty, string.Empty);
         Result result;
@@ -86,27 +81,13 @@ public class PboVersionEntry : PboEntry, IPboVersionEntry
         {
             results.Add(Validate(options));
         }
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVersionEntry::ReadPboProperties) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult = Result.Merge(results);
     }
 
     public sealed override Result Binarize(BisBinaryWriter writer, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = Result.Merge(base.Binarize(writer, options), WritePboProperties(writer, options));
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVersionEntry::Binarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
 
         return LastResult;
     }
@@ -114,10 +95,6 @@ public class PboVersionEntry : PboEntry, IPboVersionEntry
 
     public sealed override Result Debinarize(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = base.Debinarize(reader, options);
         EntryMime = (PboEntryMime)reader.ReadInt32(); // TODO WARN/ERROR then recover
         OriginalSize = reader.ReadInt32();
@@ -126,37 +103,20 @@ public class PboVersionEntry : PboEntry, IPboVersionEntry
         DataSize = reader.ReadInt32();
         LastResult = Result.Merge(LastResult, ReadPboProperties(reader, options));
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVersionEntry::Debinarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
         return LastResult;
     }
 
 
     public Result WritePboProperties(BisBinaryWriter writer, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-
-#endif
         LastResult = Result.Merge(Properties.Select(p => p.Binarize(writer, options)));
         writer.Write((byte)0);
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVersionEntry::WritePboProperties) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
         return LastResult;
     }
 
     public sealed override Result Validate(PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = Result.Merge(new List<Result>
         {
             EntryMime is not PboEntryMime.Version
@@ -175,10 +135,6 @@ public class PboVersionEntry : PboEntry, IPboVersionEntry
                 : Result.ImmutableOk()
         });
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVersionEntry::Validate) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
         return LastResult;
     }
 

--- a/src/File Formats/BisUtils.Bank/Model/PboFile.cs
+++ b/src/File Formats/BisUtils.Bank/Model/PboFile.cs
@@ -1,6 +1,5 @@
-﻿namespace BisUtils.Bank.Model;
+namespace BisUtils.Bank.Model;
 
-using System.Diagnostics;
 using Core.Binarize.Exceptions;
 using Core.Family;
 using Core.IO;
@@ -11,7 +10,6 @@ using FResults.Extensions;
 using FResults.Reasoning;
 using Options;
 using Stubs;
-using Utils;
 
 public interface IPboFile : IPboDirectory, IFamilyNode
 {
@@ -37,9 +35,6 @@ public class PboFile : PboDirectory, IPboFile
 
     public sealed override Result Debinarize(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
         var responses = new List<Result>();
         var first = true;
         options.CurrentSection = PboSection.Header;
@@ -104,10 +99,6 @@ public class PboFile : PboDirectory, IPboFile
         options.CurrentSection = PboSection.Finished;
         LastResult = Result.Merge(responses);
 
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboFile::Debinarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
         return LastResult;
     }
 

--- a/src/File Formats/BisUtils.Bank/Model/Stubs/PboDirectory.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Stubs/PboDirectory.cs
@@ -1,4 +1,4 @@
-﻿namespace BisUtils.Bank.Model.Stubs;
+namespace BisUtils.Bank.Model.Stubs;
 
 using System.Diagnostics;
 using Core.Family;
@@ -53,39 +53,16 @@ public class PboDirectory : PboVFSEntry, IPboDirectory
     public IEnumerable<IPboDataEntry> FileEntries => PboEntries.OfType<IPboDataEntry>();
     public IEnumerable<IPboDirectory> Directories => PboEntries.OfType<IPboDirectory>();
 
-    public IPboDirectory? GetDirectory(string name)
-    {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-        Console.WriteLine($"GetDirectory Called On \"{AbsolutePath}\" with {name}");
-
-#endif
-
-        var ret = Directories.FirstOrDefault(e => e.EntryName == name);
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDirectory::GetDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-        return ret;
-    }
+    public IPboDirectory? GetDirectory(string name) =>
+        Directories.FirstOrDefault(e => e.EntryName == name);
 
     public IPboDirectory CreateDirectory(string name, IPboFile? node)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-        Console.WriteLine($"CreateDirectory Called On \"{AbsolutePath}\" with {name}");
-#endif
-
         var split = name.Split('\\', 2);
         IPboDirectory ret;
 
         if (split[0].Length == 0)
         {
-#if DEBUG
-            watch.Stop();
-            Console.WriteLine($"(PboDirectory::CreateDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
             return this;
         }
 
@@ -93,11 +70,6 @@ public class PboDirectory : PboVFSEntry, IPboDirectory
         {
             if (split[1].Length == 0)
             {
-#if DEBUG
-                watch.Stop();
-                Console.WriteLine($"(PboDirectory::CreateDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
                 return i;
             }
 
@@ -107,10 +79,7 @@ public class PboDirectory : PboVFSEntry, IPboDirectory
             }
 
             ret = i.CreateDirectory(split[1], node);
-#if DEBUG
-            watch.Stop();
-            Console.WriteLine($"(PboDirectory::CreateDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
+
             return ret;
         }
 
@@ -118,39 +87,20 @@ public class PboDirectory : PboVFSEntry, IPboDirectory
         PboEntries.Add(directory);
         if (split[1].Length == 0)
         {
-#if DEBUG
-            watch.Stop();
-            Console.WriteLine($"(PboDirectory::CreateDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
             return directory;
         }
 
         ret = directory.CreateDirectory(split[1], node);
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDirectory::CreateDirectory) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return ret;
     }
 
     public override Result Binarize(BisBinaryWriter writer, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
-
         LastResult = Result.Merge
         (
             new List<Result> { Result.ImmutableOk() }.Concat(PboEntries.Select(e => e.Binarize(writer, options)))
         );
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDirectory::Binarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult;
     }
@@ -160,16 +110,7 @@ public class PboDirectory : PboVFSEntry, IPboDirectory
 
     public override Result Validate(PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = Result.Merge(PboEntries.Select(e => e.Validate(options)));
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboDirectory::Validate) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
         return LastResult;
     }
 }

--- a/src/File Formats/BisUtils.Bank/Model/Stubs/PboEntry.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Stubs/PboEntry.cs
@@ -1,10 +1,9 @@
-﻿namespace BisUtils.Bank.Model.Stubs;
+namespace BisUtils.Bank.Model.Stubs;
 
 using System.Diagnostics;
 using Core.IO;
 using Enumerations;
 using Options;
-using Utils;
 
 public interface IPboEntry : IPboVFSEntry
 {
@@ -14,27 +13,10 @@ public interface IPboEntry : IPboVFSEntry
     int TimeStamp { get; }
     int DataSize { get; }
 
-    bool IsEmptyMeta()
-    {
-        var watch = Stopwatch.StartNew();
-        var ret =
-            OriginalSize == 0 &&
-            Offset == 0 &&
-            TimeStamp == 0 &&
-            DataSize == 0;
-        watch.Stop();
-        Console.WriteLine($"(IPboEntry::IsEmptyMeta) Execution Time: {watch.ElapsedMilliseconds} ms");
-        return ret;
-    }
+    bool IsEmptyMeta() =>
+        OriginalSize == 0 && Offset == 0 && TimeStamp == 0 && DataSize == 0;
 
-    bool IsDummyEntry()
-    {
-        var watch = Stopwatch.StartNew();
-        var ret = IsEmptyMeta() && EntryName == "";
-        watch.Stop();
-        Console.WriteLine($"(IPboEntry::IsDummyEntry) Execution Time: {watch.ElapsedMilliseconds} ms");
-        return ret;
-    }
+    bool IsDummyEntry() => IsEmptyMeta() && EntryName == "";
 }
 
 public abstract class PboEntry : PboVFSEntry
@@ -67,35 +49,8 @@ public abstract class PboEntry : PboVFSEntry
     public int TimeStamp { get; set; }
     public int DataSize { get; set; }
 
-    public bool IsEmptyMeta()
-    {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-        var ret =
-            OriginalSize == 0 &&
-            Offset == 0 &&
-            TimeStamp == 0 &&
-            DataSize == 0;
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboEntry::IsEmptyMeta) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-        return ret;
-    }
+    public bool IsEmptyMeta() =>
+        OriginalSize == 0 && Offset == 0 && TimeStamp == 0 && DataSize == 0;
 
-    public bool IsDummyEntry()
-    {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
-        var ret = IsEmptyMeta() && EntryName == "";
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboEntry::IsDummyEntry) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
-
-        return ret;
-    }
+    public bool IsDummyEntry() => IsEmptyMeta() && EntryName == "";
 }

--- a/src/File Formats/BisUtils.Bank/Model/Stubs/PboProperty.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Stubs/PboProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace BisUtils.Bank.Model.Stubs;
+namespace BisUtils.Bank.Model.Stubs;
 
 using System.Diagnostics;
 using Alerts.Errors;
@@ -61,32 +61,17 @@ public class PboProperty : PboElement, IPboProperty
 
     public sealed override Result Debinarize(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         var result = reader.ReadAsciiZ(out name, options);
         LastResult = name.Length == 0
             ? Result.Fail(PboEmptyPropertyNameError.Instance)
             : Result.Merge(result, reader.ReadAsciiZ(out value, options), Validate(options));
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboProperty::Debinarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult;
     }
 
     public override Result Validate(PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
         LastResult = Result.FailIf(Name.Length == 0 || Value.Length == 0, PboEmptyPropertyNameError.Instance);
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboProperty::Validate) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult;
     }

--- a/src/File Formats/BisUtils.Bank/Model/Stubs/PboVFSEntry.cs
+++ b/src/File Formats/BisUtils.Bank/Model/Stubs/PboVFSEntry.cs
@@ -1,4 +1,4 @@
-﻿namespace BisUtils.Bank.Model.Stubs;
+namespace BisUtils.Bank.Model.Stubs;
 
 using System.Diagnostics;
 using Core.Family;
@@ -40,32 +40,16 @@ public abstract class PboVFSEntry : PboElement, IPboVFSEntry
 
     public override Result Debinarize(BisBinaryReader reader, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         LastResult = reader.ReadAsciiZ(out entryName, options);
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVFSEntry::Debinarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
+
         return LastResult;
     }
 
 
     public override Result Binarize(BisBinaryWriter writer, PboOptions options)
     {
-#if DEBUG
-        var watch = Stopwatch.StartNew();
-#endif
-
         writer.WriteAsciiZ(entryName, options);
         LastResult = Result.ImmutableOk();
-
-#if DEBUG
-        watch.Stop();
-        Console.WriteLine($"(PboVFSEntry::Binarize) Execution Time: {watch.ElapsedMilliseconds} ms");
-#endif
 
         return LastResult;
     }

--- a/test/BisUtils.Bank.Benchmarks/BisUtils.Bank.Benchmarks.csproj
+++ b/test/BisUtils.Bank.Benchmarks/BisUtils.Bank.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\File Formats\BisUtils.Bank\BisUtils.Bank.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs
+++ b/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs
@@ -1,0 +1,31 @@
+﻿namespace BisUtils.Bank.Benchmarks;
+
+using BenchmarkDotNet.Attributes;
+using BisUtils.Bank.Model;
+using BisUtils.Core.IO;
+using FResults;
+
+public class PboFileBinarizationBenchmarks
+{
+    private readonly PboFile pbo;
+    private readonly BisBinaryWriter destination;
+
+    public PboFileBinarizationBenchmarks()
+    {
+        using var fs = File.OpenRead(@"C:\Steam\steamapps\common\DayZ\Addons\weapons_data.pbo");
+        using var reader = new BisBinaryReader(fs);
+
+        pbo = new PboFile(reader, new());
+
+        destination = new BisBinaryWriter(new MemoryStream((int)fs.Length));
+    }
+
+    [IterationSetup(Target = nameof(Binarize))]
+    public void DebinarizeSetup() => destination.Seek(0, SeekOrigin.Begin);
+
+    [Benchmark]
+    public Result Binarize() => pbo.Binarize(destination, new());
+
+    [GlobalCleanup]
+    public void Cleanup() => destination.Close();
+}

--- a/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
+++ b/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
@@ -20,7 +20,7 @@ public class PboFileCreationBenchmarks
     [IterationSetup(Target = nameof(DebinarizeFlatRead))]
     public void DebinarizeFlatReadSetup() => reader.BaseStream.Position = 0;
 
-    [Benchmark(Baseline = true, OperationsPerInvoke = 100)]
+    [Benchmark(Baseline = true)]
     public PboFile DebinarizeFlatRead() => new(reader, flatReadOptions);
 
     [IterationSetup(Target = nameof(Debinarize))]

--- a/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
+++ b/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
@@ -1,0 +1,34 @@
+namespace BisUtils.Bank.Benchmarks;
+
+using BenchmarkDotNet.Attributes;
+using BisUtils.Bank.Model;
+using BisUtils.Bank.Options;
+using BisUtils.Core.IO;
+
+public class PboFileCreationBenchmarks
+{
+    private readonly BisBinaryReader reader;
+    private readonly PboOptions flatReadOptions = new() { FlatRead = true };
+    private readonly PboOptions options = new() { FlatRead = false };
+
+    public PboFileCreationBenchmarks()
+    {
+        var fs = File.OpenRead(@"C:\Steam\steamapps\common\DayZ\Addons\structures_data.pbo");
+        reader = new BisBinaryReader(fs);
+    }
+
+    [IterationSetup(Target = nameof(DebinarizeFlatRead))]
+    public void DebinarizeFlatReadSetup() => reader.BaseStream.Position = 0;
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 100)]
+    public PboFile DebinarizeFlatRead() => new(reader, flatReadOptions);
+
+    [IterationSetup(Target = nameof(Debinarize))]
+    public void DebinarizeSetup() => reader.BaseStream.Position = 0;
+
+    [Benchmark]
+    public PboFile Debinarize() => new(reader, options);
+
+    [GlobalCleanup]
+    public void Cleanup() => reader.Close();
+}

--- a/test/BisUtils.Bank.Benchmarks/Program.cs
+++ b/test/BisUtils.Bank.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);


### PR DESCRIPTION
I have started to replace the stopwatches in the debug build with benchmarks for `Bisutils.Bank`.

So far I have only added benchmarks for `PboFIle` creation and binarization. Let me know what other scenarios you would like to benchmark. 

While creating the benchmark for binarization, I noticed that `BisBinaryWriter` was missing base class constructors, so I added them for convenience.

There is a problem with resources for benchmarks. AFAIK BenchmarkDotNet  doesn't currently support runtime parameters for benchmarks. So I have to hardcode paths to PBO files (from the DayZ installation) that are used in benchmarks. This path needs to be edited if you want to run benchmarks on your machine. I'm still looking for ways to fix this and make benchmarks reproducible on any machine without modifying the code.