### PR TITLE
(Core): Add Logging Infastructure To BisUtils

### DIFF
--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -10,15 +10,65 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/BisUtils.Core/Logging/IBisLoggable.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/IBinaryObject.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/IBinaryObject.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Implementation/BinaryObject.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Implementation/BinaryObject.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Implementation/StrictBinaryObject.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Implementation/StrictBinaryObject.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizableElement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizableElement.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/BisUtils.Core.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/BisUtils.Core.csproj" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Extensions/ParserExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Extensions/ParserExtensions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/BisParser.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/BisParser.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Render/Color/Color.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Render/Color/Color.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Render/Point/Point2D.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Render/Point/Point2D.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Render/Point/Point3D.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Render/Point/Point3D.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Render/Vector/Vector2D.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Render/Vector/Vector2D.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Render/Vector/Vector3D.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Render/Vector/Vector3D.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgMod.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgMod.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgPatch.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgPatch.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Extensions/ParamStatementHolderExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Extensions/ParamStatementHolderExtensions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Factories/ParamLiteralFactory.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Factories/ParamLiteralFactory.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Factories/ParamStatementFactory.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Factories/ParamStatementFactory.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamArray.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamArray.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamFloat.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamFloat.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamInt.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamInt.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamString.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Literals/ParamString.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/ParamFile.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/ParamFile.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamClass.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamClass.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamDelete.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamDelete.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamExternalClass.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamExternalClass.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamVariable.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Statements/ParamVariable.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamElement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamElement.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamLiteral.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamLiteral.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamStatement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Models/Stubs/ParamStatement.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Utils/ParamConfigAbstraction.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Utils/ParamConfigAbstraction.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Param/Utils/ParamImplementation.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Param/Utils/ParamImplementation.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankElement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankElement.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankProperty.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankProperty.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVAnimationPhase.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVAnimationPhase.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVModelConfig.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVModelConfig.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVSharpEdge.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Data/RVSharpEdge.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Face/RVFace.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Face/RVFace.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Lod/RVLod.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Lod/RVLod.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Point/RVPoint.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Point/RVPoint.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/RVShape.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/RVShape.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Utils/RVDataVertex.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Utils/RVDataVertex.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Utils/RVResolution.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVShape/Models/Utils/RVResolution.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVTexture/Models/RVPalette.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVTexture/Models/RVPalette.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVTexture/Models/RVTexture.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVTexture/Models/RVTexture.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/Scratches/ParamTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/ParamTest/Program.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/Scratches/ShapeTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/ShapeTest/Program.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -26,11 +76,30 @@
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
   <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="main" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="HighlightingMarkupGrave">
+    <markupCoffin contentHash="-1700151165" url="file://$PROJECT_DIR$/test/Scratches/ShapeTest/Program.cs">
+      <highlighter start="275" end="289" layer="3999" target="0">
+        <option name="myExternalName" value="SUGGESTION" />
+      </highlighter>
+      <highlighter start="343" end="348" layer="4001" target="0">
+        <option name="myExternalName" value="NOT_USED_ELEMENT_ATTRIBUTES" />
+      </highlighter>
+      <highlighter start="364" end="379" layer="3999" target="0">
+        <option name="myExternalName" value="SUGGESTION" />
+      </highlighter>
+    </markupCoffin>
   </component>
   <component name="HighlightingSettingsPerFile">
     <setting file="mock:///AIAssistantSnippet" root0="SKIP_HIGHLIGHTING" />
-    <setting file="mock:///AIAssistantSnippet" root0="ESSENTIAL" />
+    <setting file="mock:///AIAssistantSnippet" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/35dda6186b16a39ac1162d64ecf0c27b8ebe94f2af6f7ce3b8e9e84698f06c37/LoggerMessage.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/9a6b1457cbcf17db31a383ba49ef9bcc786cf3ef77146d997eee499b27a46d/Object.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgMod.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzPathCtx.cs" root0="FORCE_HIGHLIGHTING" />
@@ -48,27 +117,27 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "feature/logging",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;rider.external.source.directories&quot;: [
-      &quot;C:\\Users\\ryann\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\DecompilerCache&quot;,
-      &quot;C:\\Users\\ryann\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\SourcesCache&quot;,
-      &quot;C:\\Users\\ryann\\AppData\\Local\\Symbols\\src&quot;
+  "keyToStringList": {
+    "rider.external.source.directories": [
+      "C:\\Users\\ryann\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\DecompilerCache",
+      "C:\\Users\\ryann\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\SourcesCache",
+      "C:\\Users\\ryann\\AppData\\Local\\Symbols\\src"
     ]
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected=".NET Project.ParamTest">
     <configuration name="Publish BisUtils.RVBank to folder" type="DotNetFolderPublish" factoryName="Publish to folder">
       <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/src/BisUtils.RVBank/bin/Release/net7.0/publish" target_framework="net7.0" uuid_high="-775555546124957071" uuid_low="-8586648064013952717" />
@@ -147,6 +216,7 @@
       <workItem from="1690207331819" duration="2241000" />
       <workItem from="1690216222541" duration="282000" />
       <workItem from="1690216527563" duration="920000" />
+      <workItem from="1690293944544" duration="7224000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -281,65 +351,26 @@
       <breakpoints>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs</url>
-          <line>210</line>
-          <properties documentPath="E:\projects\csharp\bisutils\src\BisUtils.Param\Parse\ParamParser.cs" initialLine="206" containingFunctionPresentation="Method 'Parse'">
-            <startOffsets>
-              <option value="8364" />
-            </startOffsets>
-            <endOffsets>
-              <option value="8412" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="1" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs</url>
-          <line>201</line>
-          <properties documentPath="E:\projects\csharp\bisutils\src\BisUtils.Param\Parse\ParamParser.cs" initialLine="201" containingFunctionPresentation="Method 'Parse'">
-            <startOffsets>
-              <option value="7948" />
-            </startOffsets>
-            <endOffsets>
-              <option value="8002" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="4" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs</url>
-          <line>203</line>
-          <properties documentPath="E:\projects\csharp\bisutils\src\BisUtils.Param\Parse\ParamParser.cs" initialLine="203" containingFunctionPresentation="Method 'Parse'">
-            <startOffsets>
-              <option value="8024" />
-            </startOffsets>
-            <endOffsets>
-              <option value="8105" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="5" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs</url>
-          <line>317</line>
+          <line>319</line>
           <properties documentPath="E:\projects\csharp\bisutils\src\BisUtils.Param\Parse\ParamParser.cs" initialLine="313" containingFunctionPresentation="Method 'ParseParamArray'">
             <startOffsets>
-              <option value="12135" />
+              <option value="12396" />
             </startOffsets>
             <endOffsets>
-              <option value="12154" />
+              <option value="12415" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="6" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.Param/Parse/ParamParser.cs</url>
-          <line>340</line>
+          <line>342</line>
           <properties documentPath="E:\projects\csharp\bisutils\src\BisUtils.Param\Parse\ParamParser.cs" initialLine="336" containingFunctionPresentation="Method 'ParseParamArray'">
             <startOffsets>
-              <option value="12866" />
+              <option value="13135" />
             </startOffsets>
             <endOffsets>
-              <option value="12875" />
+              <option value="13144" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="7" />

--- a/src/BisUtils.Core/Binarize/IBinaryObject.cs
+++ b/src/BisUtils.Core/Binarize/IBinaryObject.cs
@@ -1,5 +1,7 @@
 ﻿namespace BisUtils.Core.Binarize;
 
+using Logging;
+using Microsoft.Extensions.Logging;
 using Options;
 
 /// <summary>
@@ -7,6 +9,6 @@ using Options;
 /// This interface is suitable for types needing to provide custom logic for both binary serialization and deserialization.
 /// </summary>
 /// <typeparam name="TOptions">Specifies the type of the binarization/debinarization options to be used by the Binarize and Debinarize methods.</typeparam>
-public interface IBinaryObject<in TOptions> : IBinarizable<TOptions>, IDebinarizable<TOptions> where TOptions : IBinarizationOptions
+public interface IBinaryObject<in TOptions> : IBisLoggable, IBinarizable<TOptions>, IDebinarizable<TOptions> where TOptions : IBinarizationOptions
 {
 }

--- a/src/BisUtils.Core/Binarize/Implementation/BinaryObject.cs
+++ b/src/BisUtils.Core/Binarize/Implementation/BinaryObject.cs
@@ -2,6 +2,7 @@
 
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 /// <summary>
@@ -18,22 +19,21 @@ public abstract class BinaryObject<T> : IBinaryObject<T> where T : IBinarization
     /// </summary>
     public Result? LastResult { get; protected set; }
 
+
+    public ILogger? Logger { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BinaryObject{T}"/> class, using the specified binary reader and options for debinarization.
     /// </summary>
     /// <param name="reader">The binary reader to load data from.</param>
     /// <param name="options">The options controlling the debinarization process.</param>
-    protected BinaryObject(BisBinaryReader reader, T options)
-    {
-
-    }
+    /// <param name="logger">The logger to use </param>
+    protected BinaryObject(BisBinaryReader reader, T options, ILogger? logger) => Logger = logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BinaryObject{T}"/> class.
     /// </summary>
-    protected BinaryObject()
-    {
-    }
+    protected BinaryObject(ILogger? logger) => Logger = logger;
 
     /// <summary>
     /// Binarizes the current binary object state into a binary writer as per the provided options.
@@ -50,4 +50,5 @@ public abstract class BinaryObject<T> : IBinaryObject<T> where T : IBinarization
     /// <param name="options">The options controlling the debinarization process.</param>
     /// <returns>A Result that represents the outcome of the operation.</returns>
     public abstract Result Debinarize(BisBinaryReader reader, T options);
+
 }

--- a/src/BisUtils.Core/Binarize/Implementation/StrictBinaryObject.cs
+++ b/src/BisUtils.Core/Binarize/Implementation/StrictBinaryObject.cs
@@ -2,6 +2,7 @@
 
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 /// <summary>
@@ -18,14 +19,15 @@ public abstract class StrictBinaryObject<T> : BinaryObject<T>, IStrictBinaryObje
     /// </summary>
     /// <param name="reader">The binary reader to load data from.</param>
     /// <param name="options">The options controlling the debinarization process.</param>
-    protected StrictBinaryObject(BisBinaryReader reader, T options) : base(reader, options)
+    /// <param name="logger">The logger to use for this object</param>
+    protected StrictBinaryObject(BisBinaryReader reader, T options, ILogger? logger) : base(reader, options, logger)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StrictBinaryObject{T}" /> class.
     /// </summary>
-    protected StrictBinaryObject()
+    protected StrictBinaryObject(ILogger? logger) : base(logger)
     {
     }
 

--- a/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs
+++ b/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs
@@ -4,6 +4,7 @@ using FResults;
 using FResults.Extensions;
 using Implementation;
 using IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 /// <summary>
@@ -51,18 +52,18 @@ public abstract class BisSynchronizable<TOptions> : StrictBinaryObject<TOptions>
     }
 
 
-    protected BisSynchronizable(BisBinaryReader reader, TOptions options, Stream? syncTo) : base(reader, options)
+    protected BisSynchronizable(BisBinaryReader reader, TOptions options, Stream? syncTo, ILogger logger) : base(reader, options, logger)
     {
         SynchronizationRoot = this;
         SynchronizationStream = syncTo;
     }
 
-    protected BisSynchronizable()
+    protected BisSynchronizable(ILogger? logger) : base(logger)
     {
 
     }
 
-    protected BisSynchronizable(Stream? syncTo)
+    protected BisSynchronizable(Stream? syncTo, ILogger? logger) : base(logger)
     {
         SynchronizationRoot = this;
         ChangesMade += OnChangesMade;

--- a/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizableElement.cs
+++ b/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizableElement.cs
@@ -3,6 +3,7 @@
 using FResults;
 using Implementation;
 using IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 /// <summary>
@@ -43,7 +44,7 @@ public abstract class BisSynchronizableElement<TOptions> : BinaryObject<TOptions
     public event EventHandler? ChangesMade;
     public event EventHandler? ChangesSaved;
 
-    protected BisSynchronizableElement(IBisSynchronizable<TOptions> synchronizationRoot)
+    protected BisSynchronizableElement(IBisSynchronizable<TOptions> synchronizationRoot, ILogger? logger) : base(logger)
     {
         IsStale = false;
         SynchronizationRoot = synchronizationRoot;
@@ -51,7 +52,7 @@ public abstract class BisSynchronizableElement<TOptions> : BinaryObject<TOptions
     }
 
     protected BisSynchronizableElement(BisBinaryReader reader, TOptions options,
-        IBisSynchronizable<TOptions> synchronizationRoot) : base(reader, options)
+        IBisSynchronizable<TOptions> synchronizationRoot, ILogger? logger) : base(reader, options, logger)
     {
         IsStale = false;
         SynchronizationRoot = synchronizationRoot;
@@ -74,7 +75,7 @@ public abstract class BisSynchronizableElement<TOptions> : BinaryObject<TOptions
     //Sender will usually be 'this' unless there are child elements
     protected virtual void OnChangesMade(object? sender, EventArgs e)
     {
-
+        Logger?.LogDebug("");
         IsStale = true;
         ChangesMade?.Invoke(sender, e);
     }

--- a/src/BisUtils.Core/BisUtils.Core.csproj
+++ b/src/BisUtils.Core/BisUtils.Core.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\lib\FResults\FResults\FResults.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.6.23329.7" />
+
   </ItemGroup>
 
 

--- a/src/BisUtils.Core/Extensions/ParserExtensions.cs
+++ b/src/BisUtils.Core/Extensions/ParserExtensions.cs
@@ -2,6 +2,7 @@
 
 using System.Text;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Parsing;
 using Parsing.Lexer;
 
@@ -12,6 +13,7 @@ public static class ParserExtensions
         this IBisParser<TAstNode, TLexer, TTypes, TPreProcessor> parser,
         out TAstNode? node,
         TLexer lexer,
+        ILogger? logger,
         TPreProcessor? preprocessor = null
     ) where TLexer : BisLexer<TTypes> where TTypes : Enum where TPreProcessor : BisPreProcessorBase, new()
     {
@@ -19,6 +21,6 @@ public static class ParserExtensions
         preprocessor ??= new TPreProcessor();
         preprocessor.EvaluateLexer(lexer, builder);
         lexer.ResetLexer(builder.ToString());
-        return parser.Parse(out node, lexer);
+        return parser.Parse(out node, lexer, logger);
     }
 }

--- a/src/BisUtils.Core/Logging/IBisLoggable.cs
+++ b/src/BisUtils.Core/Logging/IBisLoggable.cs
@@ -1,0 +1,8 @@
+﻿namespace BisUtils.Core.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public interface IBisLoggable
+{
+    public ILogger? Logger { get; }
+}

--- a/src/BisUtils.Core/Parsing/BisParser.cs
+++ b/src/BisUtils.Core/Parsing/BisParser.cs
@@ -3,6 +3,7 @@
 using System.Text;
 using FResults;
 using Lexer;
+using Microsoft.Extensions.Logging;
 
 #pragma warning disable CA1000
 
@@ -19,8 +20,9 @@ public interface IBisParser<TAstNode, in TLexer, TTypes> where TLexer : BisLexer
     /// </summary>
     /// <param name="node">The output abstract syntax tree node.</param>
     /// <param name="lexer">The lexer to parse.</param>
+    /// <param name="logger">The logger used for parsing.</param>
     /// <returns>A result of the parsing operation.</returns>
-    public Result Parse(out TAstNode? node, TLexer lexer);
+    public Result Parse(out TAstNode? node, TLexer lexer, ILogger? logger);
 }
 
 /// <summary>
@@ -37,20 +39,23 @@ public interface IBisParser<TAstNode, in TLexer, TTypes, in TPreprocessor> : IBi
     /// </summary>
     /// <param name="node">The output abstract syntax tree node.</param>
     /// <param name="lexer">The lexer to parse.</param>
+    /// <param name="logger">The logger used for parsing</param>
     /// <param name="preprocessor">The preprocessor to use. If not specified, a new instance of `TPreprocessor` is created.</param>
     /// <returns>A result of the parsing and preprocessing operation.</returns>
     public Result ProcessAndParse
     (
         out TAstNode? node,
         TLexer lexer,
+        ILogger logger,
         TPreprocessor? preprocessor = null
+
     )
     {
         var builder = new StringBuilder();
         preprocessor ??= new TPreprocessor();
         preprocessor.EvaluateLexer(lexer, builder);
         lexer.ResetLexer(builder.ToString());
-        return Parse(out node, lexer);
+        return Parse(out node, lexer, logger);
     }
 }
 

--- a/src/BisUtils.Core/Render/Color/Color.cs
+++ b/src/BisUtils.Core/Render/Color/Color.cs
@@ -4,6 +4,7 @@ using Binarize;
 using Extensions;
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IColor : IBinaryObject<IBisColorOptions>
@@ -24,6 +25,7 @@ public struct Color : IColor
     public float Green { get; private set; }
     public float Blue { get; private set; }
     public float Alpha { get; private set; }
+    public ILogger? Logger { get; }
 
     public int PackColor()
     {
@@ -35,20 +37,23 @@ public struct Color : IColor
         return value;
     }
 
-    public Color(float red, float green, float blue, float alpha)
+    public Color(float red, float green, float blue, float alpha, ILogger? logger)
     {
         Red = red;
         Green = green;
         Blue = blue;
         Alpha = alpha;
+        Logger = logger;
     }
 
-    public Color(BisBinaryReader reader, IBisColorOptions options)
+    public Color(BisBinaryReader reader, IBisColorOptions options, ILogger? logger)
     {
+        Logger = logger;
         if (!Debinarize(reader, options))
         {
             LastResult!.Throw();
         }
+
     }
 
     public Color(BisBinaryReader reader, bool writePacked)
@@ -105,4 +110,5 @@ public struct Color : IColor
             }
         }
     }
+
 }

--- a/src/BisUtils.Core/Render/Point/Point2D.cs
+++ b/src/BisUtils.Core/Render/Point/Point2D.cs
@@ -5,6 +5,7 @@ using Binarize.Options;
 using Extensions;
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 
 public interface IPoint2D
 {
@@ -27,7 +28,7 @@ public readonly struct Point2D : IPoint2D
     {
     }
 
-    public static implicit operator BinarizablePoint2D(Point2D point) => new(point.X, point.Y);
+    public static implicit operator BinarizablePoint2D(Point2D point) => new(point.X, point.Y, null!);
     public static explicit operator Point2D(BinarizablePoint2D point) => new(point.X, point.Y);
 }
 
@@ -38,25 +39,25 @@ public class BinarizablePoint2D : BinaryObject<IBinarizationOptions>, IPoint2D
     public int Y { get; private set; }
 
     public static implicit operator Point2D(BinarizablePoint2D point) => new(point.X, point.Y);
-    public static explicit operator BinarizablePoint2D(Point2D point) => new(point.X, point.Y);
+    public static explicit operator BinarizablePoint2D(Point2D point) => new(point.X, point.Y, null!);
 
-    public BinarizablePoint2D(int x, int y)
+    public BinarizablePoint2D(int x, int y, ILogger? logger) : base(logger)
     {
         X = x;
         Y = y;
     }
 
-    public BinarizablePoint2D(float x, float y) : this(Convert.ToInt32(x), Convert.ToInt32(y))
+    public BinarizablePoint2D(float x, float y, ILogger? logger) : this(Convert.ToInt32(x), Convert.ToInt32(y), logger)
     {
     }
 
     // ReSharper disable once UnusedParameter.Local
-    protected BinarizablePoint2D(BisBinaryReader reader, IBinarizationOptions options, bool _) : base(reader, options)
+    protected BinarizablePoint2D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger, bool _) : base(reader, options, logger)
     {
 
     }
 
-    public BinarizablePoint2D(BisBinaryReader reader, IBinarizationOptions options) : base(reader, options)
+    public BinarizablePoint2D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Core/Render/Point/Point3D.cs
+++ b/src/BisUtils.Core/Render/Point/Point3D.cs
@@ -5,6 +5,7 @@ using Binarize.Options;
 using Extensions;
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 
 public interface IPoint3D : IPoint2D
 {
@@ -28,7 +29,7 @@ public readonly struct Point3D : IPoint3D
     {
     }
 
-    public static implicit operator BinarizablePoint3D(Point3D point) => new(point.X, point.Y, point.Z);
+    public static implicit operator BinarizablePoint3D(Point3D point) => new(point.X, point.Y, point.Z, null!);
     public static explicit operator Point3D(BinarizablePoint3D point) => new(point.X, point.Y, point.Z);
 }
 
@@ -40,26 +41,26 @@ public class BinarizablePoint3D : BinaryObject<IBinarizationOptions>, IPoint3D
     public int Z { get; private set; }
 
     public static implicit operator Point3D(BinarizablePoint3D point) => new(point.X, point.Y, point.Z);
-    public static explicit operator BinarizablePoint3D(Point3D point) => new(point.X, point.Y, point.Z);
+    public static explicit operator BinarizablePoint3D(Point3D point) => new(point.X, point.Y, point.Z, null);
 
-    public BinarizablePoint3D(int x, int y, int z)
+    public BinarizablePoint3D(int x, int y, int z, ILogger? logger) : base(logger)
     {
         X = x;
         Y = y;
         Z = z;
     }
 
-    public BinarizablePoint3D(float x, float y, float z) : this(Convert.ToInt32(x), Convert.ToInt32(y), Convert.ToInt32(z))
+    public BinarizablePoint3D(float x, float y, float z, ILogger? logger) : this(Convert.ToInt32(x), Convert.ToInt32(y), Convert.ToInt32(z), logger)
     {
     }
 
     // ReSharper disable once UnusedParameter.Local
-    protected BinarizablePoint3D(BisBinaryReader reader, IBinarizationOptions options, bool _) : base(reader, options)
+    protected BinarizablePoint3D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger, bool _) : base(reader, options, logger)
     {
 
     }
 
-    public BinarizablePoint3D(BisBinaryReader reader, IBinarizationOptions options) : base(reader, options)
+    public BinarizablePoint3D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Core/Render/Vector/Vector2D.cs
+++ b/src/BisUtils.Core/Render/Vector/Vector2D.cs
@@ -5,6 +5,7 @@ using Binarize.Options;
 using Extensions;
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
 using Point;
 
 public interface IVector2D
@@ -28,7 +29,7 @@ public readonly struct Vector2D : IVector2D
     {
 
     }
-    public static implicit operator BinarizablePoint2D(Vector2D point) => new(point.X, point.Y);
+    public static implicit operator BinarizablePoint2D(Vector2D point) => new(point.X, point.Y, null!);
     public static explicit operator Vector2D(BinarizablePoint2D point) => new(point.X, point.Y);
 }
 
@@ -39,25 +40,25 @@ public class BinarizableVector2D : BinaryObject<IBinarizationOptions>, IVector2D
     public float Y { get; private set; }
 
     public static implicit operator Vector2D(BinarizableVector2D point) => new(point.X, point.Y);
-    public static explicit operator BinarizableVector2D(Vector2D point) => new(point.X, point.Y);
+    public static explicit operator BinarizableVector2D(Vector2D point) => new(point.X, point.Y, null!);
 
-    public BinarizableVector2D(int x, int y) : this((float)x, y)
+    public BinarizableVector2D(int x, int y, ILogger? logger) : this((float)x, y, logger)
     {
     }
 
-    public BinarizableVector2D(float x, float y)
+    public BinarizableVector2D(float x, float y, ILogger? logger) : base(logger)
     {
         X = x;
         Y = y;
     }
 
     // ReSharper disable once UnusedParameter.Local
-    protected BinarizableVector2D(BisBinaryReader reader, IBinarizationOptions options, bool _) : base(reader, options)
+    protected BinarizableVector2D(BisBinaryReader reader, IBinarizationOptions options, bool _, ILogger? logger) : base(reader, options, logger)
     {
 
     }
 
-    public BinarizableVector2D(BisBinaryReader reader, IBinarizationOptions options) : base(reader, options)
+    public BinarizableVector2D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Core/Render/Vector/Vector3D.cs
+++ b/src/BisUtils.Core/Render/Vector/Vector3D.cs
@@ -5,6 +5,8 @@ using Binarize.Options;
 using Extensions;
 using FResults;
 using IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public interface IVector3D : IVector2D
 {
@@ -36,7 +38,7 @@ public readonly struct Vector3D : IVector3D
     public Vector3D(int x, int y, int z) : this(Convert.ToSingle(x), Convert.ToSingle(y), Convert.ToSingle(z))
     {
     }
-    public static implicit operator BinarizableVector3D(Vector3D point) => new(point.X, point.Y, point.Z);
+    public static implicit operator BinarizableVector3D(Vector3D point) => new(point.X, point.Y, point.Z, null);
     public static explicit operator Vector3D(BinarizableVector3D point) => new(point.X, point.Y, point.Z);
 }
 
@@ -47,27 +49,32 @@ public class BinarizableVector3D : BinaryObject<IBinarizationOptions>, IVector3D
     public float Z { get; private set; }
 
     public static implicit operator Vector3D(BinarizableVector3D point) => new(point.X, point.Y, point.Z);
-    public static explicit operator BinarizableVector3D(Vector3D point) => new(point.X, point.Y, point.Z);
+    public static explicit operator BinarizableVector3D(Vector3D point) => new(point.X, point.Y, point.Z, null!);
 
-    public BinarizableVector3D(float x, float y, float z)
+    public BinarizableVector3D(float x, float y, float z, ILogger? logger) : base(logger)
     {
         X = x;
         Y = y;
         Z = z;
     }
 
-    public BinarizableVector3D()
+    public BinarizableVector3D() : base(NullLogger.Instance)
+    {
+
+    }
+
+    public BinarizableVector3D(ILogger? logger) : base(logger)
     {
 
     }
 
     // ReSharper disable once UnusedParameter.Local
-    protected BinarizableVector3D(BisBinaryReader reader, IBinarizationOptions options, bool _) : base(reader, options)
+    protected BinarizableVector3D(BisBinaryReader reader, IBinarizationOptions options, bool _, ILogger? logger) : base(reader, options, logger)
     {
 
     }
 
-    public BinarizableVector3D(BisBinaryReader reader, IBinarizationOptions options) : base(reader, options)
+    public BinarizableVector3D(BisBinaryReader reader, IBinarizationOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.DZConfig/Models/DzCfgMod.cs
+++ b/src/BisUtils.DZConfig/Models/DzCfgMod.cs
@@ -20,6 +20,7 @@ public interface IDzCfgMod : IParamConfigAbstraction<IParamClass>
 public class DzCfgMod : ParamConfigAbstraction<IParamClass>, IDzCfgMod
 {
     private IParamClass? DefinitionsClass { get; }
+    //TODO: Logger on ParamConfigAbstraction
     public IEnumerable<string>? Dependencies
     {
         get => GetArrayValues("dependencies");

--- a/src/BisUtils.DZConfig/Models/DzCfgPatch.cs
+++ b/src/BisUtils.DZConfig/Models/DzCfgPatch.cs
@@ -1,10 +1,6 @@
 ﻿namespace BisUtils.DZConfig.Models;
 
-using Param.Enumerations;
-using Param.Extensions;
-using Param.Models.Literals;
 using Param.Models.Statements;
-using Param.Models.Stubs;
 using Param.Utils;
 
 public interface IDzCfgPatch : IParamConfigAbstraction<IParamClass>

--- a/src/BisUtils.Param/Extensions/ParamStatementHolderExtensions.cs
+++ b/src/BisUtils.Param/Extensions/ParamStatementHolderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace BisUtils.Param.Extensions;
 
 using Enumerations;
+using Microsoft.Extensions.Logging;
 using Models.Literals;
 using Models.Statements;
 using Models.Stubs;
@@ -79,11 +80,11 @@ public static class ParamStatementHolderExtensions
         return null;
     }
 
-    public static T CreateVariable<T>(this IParamStatementHolder ctx, string name, T value) where T : IParamLiteral => (T) new ParamVariable(ctx.ParamFile, ctx, name, value).VariableValue;
+    public static T CreateVariable<T>(this IParamStatementHolder ctx, string name, T value, ILogger? logger) where T : IParamLiteral => (T) new ParamVariable(name, value, ParamOperatorType.Assign, ctx.ParamFile, ctx, logger).VariableValue;
 
-    public static T AddVariable<T>(this IParamStatementHolder ctx, string name, T value) where T : IParamLiteral
+    public static T AddVariable<T>(this IParamStatementHolder ctx, string name, T value, ILogger? logger) where T : IParamLiteral
     {
-        var variable = new ParamVariable(ctx.ParamFile, ctx, name, value);
+        var variable = new ParamVariable(name, value, ParamOperatorType.Assign, ctx.ParamFile, ctx, logger);
         ctx.Statements.Add(variable);
         return (T)variable.VariableValue;
 

--- a/src/BisUtils.Param/Factories/ParamLiteralFactory.cs
+++ b/src/BisUtils.Param/Factories/ParamLiteralFactory.cs
@@ -2,6 +2,7 @@
 
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Models;
 using Models.Literals;
 using Models.Stubs;
@@ -11,15 +12,15 @@ using Options;
 public static class ParamLiteralFactory
 {
 
-    public static Result ReadLiteral(IParamFile? file, IParamLiteralHolder? parent, BisBinaryReader reader,
-        ParamOptions options, out IParamLiteral? literal)
+    public static Result ReadLiteral(BisBinaryReader reader,
+        ParamOptions options, out IParamLiteral? literal, IParamFile file, IParamLiteralHolder parent, ILogger? logger)
     {
         literal = (options.LastLiteralId = reader.ReadByte()) switch
         {
-            0 => new ParamString(file, parent, reader, options),
-            1 => new ParamFloat(file, parent, reader, options),
-            2 => new ParamInt(file, parent, reader, options),
-            3 => new ParamArray(file, parent, reader, options),
+            0 => new ParamString(reader, options, file, parent, logger),
+            1 => new ParamFloat(reader, options, file, parent, logger),
+            2 => new ParamInt(reader, options, file, parent, logger),
+            3 => new ParamArray(reader, options, file, parent, logger),
             _ => null
         };//TODO: Get IDs From Types
         if (literal is null)

--- a/src/BisUtils.Param/Factories/ParamStatementFactory.cs
+++ b/src/BisUtils.Param/Factories/ParamStatementFactory.cs
@@ -2,6 +2,7 @@
 
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Models;
 using Models.Statements;
 using Models.Stubs;
@@ -10,14 +11,14 @@ using Options;
 
 public static class ParamStatementFactory
 {
-    public static Result ReadStatement(IParamFile? file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options, out IParamStatement? statement)
+    public static Result ReadStatement(BisBinaryReader reader, ParamOptions options, out IParamStatement? statement, IParamFile file, IParamStatementHolder parent, ILogger? logger)
     {
         statement = (options.LastStatementId = reader.ReadByte()) switch
         {
-            0 => new ParamClass(file, parent, reader, options),
-            1 or 2 or 5 => new ParamVariable(file, parent, reader, options),
-            3 => new ParamExternalClass(file, parent, reader, options),
-            4 => new ParamDelete(file, parent, reader, options),
+            0 => new ParamClass(reader, options, file, parent, logger),
+            1 or 2 or 5 => new ParamVariable(reader, options, file, parent, logger),
+            3 => new ParamExternalClass(reader, options, file, parent, logger),
+            4 => new ParamDelete(reader, options, file, parent, logger),
             _ => null
         };
         if (statement is null)

--- a/src/BisUtils.Param/Models/Literals/ParamFloat.cs
+++ b/src/BisUtils.Param/Models/Literals/ParamFloat.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Core.Extensions;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -18,11 +19,11 @@ public class ParamFloat : ParamLiteral<float>, IParamFloat
     public override byte LiteralId => 1;
     public override float Value { get; set; }
 
-    public ParamFloat(IParamFile file, IParamLiteralHolder parent, float value) : base(file, parent, value)
+    public ParamFloat(float value, IParamFile file, IParamLiteralHolder parent, ILogger? logger) : base(value, file, parent, logger)
     {
     }
 
-    public ParamFloat(IParamFile file, IParamLiteralHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    public ParamFloat(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamLiteralHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Param/Models/Literals/ParamInt.cs
+++ b/src/BisUtils.Param/Models/Literals/ParamInt.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Core.Extensions;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -19,11 +20,11 @@ public class ParamInt : ParamLiteral<int>, IParamInt
     public override byte LiteralId => 2;
     public override int Value { get; set; }
 
-    public ParamInt(IParamFile file, IParamLiteralHolder parent, int value) : base(file, parent, value)
+    public ParamInt(int value, IParamFile file, IParamLiteralHolder parent, ILogger? logger) : base(value, file, parent, logger)
     {
     }
 
-    public ParamInt(IParamFile file, IParamLiteralHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    public ParamInt(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamLiteralHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Param/Models/ParamFile.cs
+++ b/src/BisUtils.Param/Models/ParamFile.cs
@@ -5,6 +5,7 @@ using Core.IO;
 using FResults;
 using FResults.Extensions;
 using Lexer;
+using Microsoft.Extensions.Logging;
 using Options;
 using Parse;
 using Statements;
@@ -19,13 +20,13 @@ public class ParamFile : ParamClass, IParamFile
 {
     public string FileName { get => ClassName; set => ClassName = value; }
 
-    public ParamFile(string fileName, List<IParamStatement> statements ) : base(null!, null!, fileName, null, statements)
+    public ParamFile(string fileName, List<IParamStatement> statements, ILogger? logger) : base( fileName, null, statements, null!, null!, logger)
     {
         FileName = fileName;
         Statements = statements;
     }
 
-    public ParamFile(string fileName, BisBinaryReader reader, ParamOptions options) : base(null!, null!, reader, options)
+    public ParamFile(string fileName, BisBinaryReader reader, ParamOptions options, ILogger? logger) : base(reader, options, null!, null!, logger)
     {
         FileName = fileName;
         if (!Debinarize(reader, options))
@@ -37,7 +38,7 @@ public class ParamFile : ParamClass, IParamFile
     public override Result Binarize(BisBinaryWriter writer, ParamOptions options) => throw new NotImplementedException();
 
 
-    public static ParamFile? ReadParamFile(string fileName, Stream stream, ParamOptions options)
+    public static ParamFile? ReadParamFile(string fileName, Stream stream, ParamOptions options, ILogger? logger)
     {
         stream.Seek(0, SeekOrigin.Begin);
         using var memory = new MemoryStream();
@@ -53,11 +54,11 @@ public class ParamFile : ParamClass, IParamFile
             var content = options.Charset.GetString(memory.ToArray());
             Console.WriteLine(content);
             var lexer = new ParamLexer(content);
-            var result = ParamParser.Instance.Parse(out var node, lexer);
+            var result = ParamParser.Instance.Parse(out var node, lexer, logger);
             return node;
         }
         reader.BaseStream.Seek(-4, SeekOrigin.Current);
-        return new ParamFile(fileName, reader, options);
+        return new ParamFile(fileName, reader, options, logger);
     }
 
     private new Result Debinarize(BisBinaryReader reader, ParamOptions options)

--- a/src/BisUtils.Param/Models/Statements/ParamClass.cs
+++ b/src/BisUtils.Param/Models/Statements/ParamClass.cs
@@ -9,6 +9,7 @@ using Factories;
 using FResults;
 using FResults.Extensions;
 using FResults.Reasoning;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -29,20 +30,21 @@ public class ParamClass : ParamStatement, IParamClass
     public List<IParamStatement> Statements { get; set; }
 
     public ParamClass(
+        string className,
+        string? inheritedClassname,
+        List<IParamStatement>? statements,
         IParamFile file,
         IParamStatementHolder parent,
-        string className,
-        string? inheritedClassname = null,
-        List<IParamStatement>? statements = null
-    ) : base(file, parent)
+        ILogger? logger
+    ) : base(file, parent, logger)
     {
         Statements = statements ?? new List<IParamStatement>();
         ClassName = className;
         InheritedClassname = inheritedClassname;
     }
 
-    public ParamClass(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options) :
-        base(file, parent, reader, options)
+    public ParamClass(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) :
+        base(reader, options, file, parent, logger)
     {
         Statements = new List<IParamStatement>();
         if (!Debinarize(reader, options))
@@ -93,7 +95,7 @@ public class ParamClass : ParamStatement, IParamClass
 
         for (var i = 0; i < reader.ReadCompactInteger(); i++)
         {
-            value.WithReasons(ParamStatementFactory.ReadStatement(ParamFile, this, reader, options, out var statement)
+            value.WithReasons(ParamStatementFactory.ReadStatement(reader, options, out var statement, ParamFile, this, Logger)
                 .Reasons);
             if (statement is null)
             {

--- a/src/BisUtils.Param/Models/Statements/ParamDelete.cs
+++ b/src/BisUtils.Param/Models/Statements/ParamDelete.cs
@@ -5,6 +5,7 @@ using Core.Extensions;
 using Core.IO;
 using Extensions;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -20,10 +21,10 @@ public class ParamDelete : ParamStatement, IParamDelete
     public override byte StatementId => 4;
     public string DeleteTargetName { get; set; } = null!;
 
-    public ParamDelete(IParamFile file, IParamStatementHolder parent, string target) : base(file, parent) =>
+    public ParamDelete(string target, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(file, parent, logger) =>
         DeleteTargetName = target;
 
-    public ParamDelete(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    public ParamDelete(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Param/Models/Statements/ParamExternalClass.cs
+++ b/src/BisUtils.Param/Models/Statements/ParamExternalClass.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Core.Extensions;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -18,9 +19,9 @@ public class ParamExternalClass : ParamStatement, IParamExternalClass
     public string ClassName { get; set; } = null!;
     public override byte StatementId => 3;
 
-    public ParamExternalClass(IParamFile file, IParamStatementHolder parent, string className) : base(file, parent) => ClassName = className;
+    public ParamExternalClass(string className, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(file, parent, logger) => ClassName = className;
 
-    public ParamExternalClass(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    public ParamExternalClass(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.Param/Models/Statements/ParamVariable.cs
+++ b/src/BisUtils.Param/Models/Statements/ParamVariable.cs
@@ -8,6 +8,7 @@ using Factories;
 using FResults;
 using FResults.Extensions;
 using Literals;
+using Microsoft.Extensions.Logging;
 using Options;
 using Stubs;
 using Stubs.Holders;
@@ -33,11 +34,11 @@ public abstract class ParamVariableBase : ParamStatement, IParamVariable
         set => VariableValue = value[0];
     }
 
-    protected ParamVariableBase(IParamFile file, IParamStatementHolder parent) : base(file, parent)
+    protected ParamVariableBase(IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(file, parent, logger)
     {
     }
 
-    protected ParamVariableBase(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    protected ParamVariableBase(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
     }
 
@@ -64,14 +65,14 @@ public class ParamVariable : ParamVariableBase, IParamVariable
     }
 
 
-    public ParamVariable(IParamFile file, IParamStatementHolder parent, string variableName, IParamLiteral variableValue, ParamOperatorType operatorType = ParamOperatorType.Assign) : base(file, parent)
+    public ParamVariable(string variableName, IParamLiteral variableValue, ParamOperatorType operatorType, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(file, parent, logger)
     {
         VariableName = variableName;
         VariableOperator = operatorType;
         VariableValue = variableValue;
     }
 
-    public ParamVariable(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader, ParamOptions options) : base(file, parent, reader, options)
+    public ParamVariable(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -99,7 +100,7 @@ public class ParamVariable : ParamVariableBase, IParamVariable
 
         var result = reader.ReadAsciiZ(out var name, options);
         VariableName = name;
-        result.WithReasons(ParamLiteralFactory.ReadLiteral(ParamFile, this, reader, options, out var value).Reasons);
+        result.WithReasons(ParamLiteralFactory.ReadLiteral(reader, options, out var value, ParamFile, this, Logger).Reasons);
         VariableValue = value!;
         return result;
     }

--- a/src/BisUtils.Param/Models/Stubs/ParamElement.cs
+++ b/src/BisUtils.Param/Models/Stubs/ParamElement.cs
@@ -5,6 +5,7 @@ using Core.Binarize;
 using Core.Binarize.Implementation;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IParamElement : IStrictBinaryObject<ParamOptions>
@@ -18,9 +19,9 @@ public abstract class ParamElement : StrictBinaryObject<ParamOptions>, IParamEle
 {
     public IParamFile ParamFile { get; set; }
 
-    protected ParamElement(IParamFile file) => ParamFile = file;
+    protected ParamElement(IParamFile file, ILogger? logger) : base(logger) => ParamFile = file;
 
-    protected ParamElement(IParamFile file, BisBinaryReader reader, ParamOptions options) : base(reader, options) =>
+    protected ParamElement(BisBinaryReader reader, ParamOptions options, IParamFile file, ILogger? logger) : base(reader, options, logger) =>
         ParamFile = file;
 
     public abstract Result WriteParam(ref StringBuilder builder, ParamOptions options);

--- a/src/BisUtils.Param/Models/Stubs/ParamLiteral.cs
+++ b/src/BisUtils.Param/Models/Stubs/ParamLiteral.cs
@@ -3,6 +3,7 @@
 using Core.IO;
 using FResults;
 using Holders;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IParamLiteral : IParamElement
@@ -25,14 +26,14 @@ public abstract class ParamLiteral<T> : ParamElement, IParamLiteral<T>
     public IParamLiteralHolder Parent { get; set; }
     public abstract T Value { get; set; }
 
-    protected ParamLiteral(IParamFile file, IParamLiteralHolder parent, T? value) : base(file)
+    protected ParamLiteral(T? value, IParamFile file, IParamLiteralHolder parent, ILogger? logger) : base(file, logger)
     {
         ParamValue = value;
         Parent = parent;
     }
 
-    protected ParamLiteral(IParamFile file, IParamLiteralHolder parent, BisBinaryReader reader, ParamOptions options)
-        : base(file, reader, options) =>
+    protected ParamLiteral(BisBinaryReader reader, ParamOptions options, IParamFile file, IParamLiteralHolder parent, ILogger? logger)
+        : base(reader, options, file, logger) =>
         Parent = parent;
 
     public object? ParamValue

--- a/src/BisUtils.Param/Models/Stubs/ParamStatement.cs
+++ b/src/BisUtils.Param/Models/Stubs/ParamStatement.cs
@@ -3,6 +3,7 @@
 using Core.IO;
 using FResults;
 using Holders;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IParamStatement : IParamElement
@@ -14,11 +15,11 @@ public interface IParamStatement : IParamElement
 
 public abstract class ParamStatement : ParamElement, IParamStatement
 {
-    protected ParamStatement(IParamFile file, IParamStatementHolder parent) : base(file) =>
+    protected ParamStatement(IParamFile file, IParamStatementHolder parent, ILogger? logger) : base(file, logger) =>
         ParentClass = parent;
 
-    protected ParamStatement(IParamFile file, IParamStatementHolder parent, BisBinaryReader reader,
-        ParamOptions options) : base(file, reader, options) =>
+    protected ParamStatement(  BisBinaryReader reader,
+        ParamOptions options, IParamFile file, IParamStatementHolder parent, ILogger? logger) : base( reader, options, file, logger) =>
         ParentClass = parent;
 
     public abstract byte StatementId { get; }

--- a/src/BisUtils.Param/Utils/ParamImplementation.cs
+++ b/src/BisUtils.Param/Utils/ParamImplementation.cs
@@ -5,7 +5,9 @@ using Core.Binarize.Implementation;
 using Core.Extensions;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Models;
+using Models.Stubs;
 using Options;
 
 public interface IParamImplementation : IBinaryObject<ParamOptions>
@@ -19,11 +21,11 @@ public class ParamImplementation : BinaryObject<ParamOptions>, IParamImplementat
     public IParamFile ParamFile { get; set; }
     public string Name { get => ParamFile.FileName; set => ParamFile.FileName = value; }
 
-    protected ParamImplementation(IParamFile paramFile) => ParamFile = paramFile;
+    protected ParamImplementation(IParamFile paramFile) : base(((ParamElement)paramFile).Logger) => ParamFile = paramFile;
 
-    protected ParamImplementation(string name, BisBinaryReader reader, ParamOptions options)
+    protected ParamImplementation(string name, BisBinaryReader reader, ParamOptions options, ILogger? logger) : base(logger)
     {
-        ParamFile = new ParamFile(name, reader, options);
+        ParamFile = new ParamFile(name, reader, options, logger);
         if (ParamFile.LastResult is { } result && result)
         {
             result.Throw();

--- a/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
+++ b/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
@@ -61,22 +61,22 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
         uint offset,
         uint timeStamp,
         uint dataSize
-    ) : base(logger, file, parent, fileName, mime, originalSize, offset, timeStamp, dataSize)
+    ) : base(fileName, mime, originalSize, offset, timeStamp, dataSize, file, parent, logger)
     {
     }
 
     public RVBankDataEntry
     (
-        ILogger logger,
-        IRVBank file,
-        IRVBankDirectory parent,
         string fileName,
         RVBankEntryMime mime,
         uint offset,
         uint timeStamp,
         Stream entryData,
-        RVBankDataType? packingMethod = null
-    ) : base(logger, file, parent, fileName, mime, (uint) entryData.Length, offset, timeStamp, 0) =>
+        RVBankDataType? packingMethod,
+        IRVBank file,
+        IRVBankDirectory parent,
+        ILogger? logger
+    ) : base(fileName, mime, (uint) entryData.Length, offset, timeStamp, 0, file, parent, logger) =>
         this.packingMethod = packingMethod ?? AssumePackingMethod();
 
     private RVBankDataType AssumePackingMethod()
@@ -99,7 +99,7 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
 
     protected sealed override void OnChangesMade(object? sender, EventArgs? e) => base.OnChangesMade(sender, e);
 
-    public RVBankDataEntry(ILogger logger, IRVBank file, IRVBankDirectory parent, BisBinaryReader reader, RVBankOptions options) : base(logger, file, parent, reader, options)
+    public RVBankDataEntry(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankDirectory parent, ILogger? logger) : base(reader, options, file, parent, logger)
     {
         Debinarize(reader, options);
         if (LastResult!.IsFailed)
@@ -122,7 +122,7 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
         }
         EntryName = RVPathUtilities.GetFilename(EntryName);
 
-        ParentDirectory = BankFile.CreateDirectory(RVPathUtilities.GetParent(normalizePath), BankFile);
+        ParentDirectory = BankFile.CreateDirectory(RVPathUtilities.GetParent(normalizePath), BankFile, Logger);
         Move(ParentDirectory);
     }
 

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs
@@ -7,6 +7,7 @@ using Entry;
 using Extensions;
 using FResults;
 using FResults.Extensions;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVBankDirectory : IRVBankEntry
@@ -48,14 +49,15 @@ public class RVBankDirectory : RVBankVfsEntry, IRVBankDirectory
     public IEnumerable<IRVBankDirectory> Directories => PboEntries.OfType<IRVBankDirectory>();
 
     public RVBankDirectory(
+        IEnumerable<IRVBankEntry> entries,
+        string directoryName,
         IRVBank file,
         IRVBankDirectory parent,
-        IEnumerable<IRVBankEntry> entries,
-        string directoryName
-    ) : base(file, parent, directoryName) =>
+        ILogger? logger
+    ) : base(directoryName, file, parent, logger) =>
         PboEntries = new ObservableCollection<IRVBankEntry>(entries);
 
-    protected RVBankDirectory(IRVBank file, IRVBankDirectory parent, BisBinaryReader reader, RVBankOptions options) : base(file, parent, reader, options) =>
+    protected RVBankDirectory(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankDirectory parent, ILogger? logger) : base(reader, options, file, parent, logger) =>
         PboEntries = new ObservableCollection<IRVBankEntry>();
 
     public override Result Binarize(BisBinaryWriter writer, RVBankOptions options) =>

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankElement.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankElement.cs
@@ -2,6 +2,7 @@
 
 using Core.Binarize.Synchronization;
 using Core.IO;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVBankElement : IBisSynchronizableElement<RVBankOptions>
@@ -14,10 +15,10 @@ public abstract class RVBankElement : BisSynchronizableElement<RVBankOptions>, I
     public IRVBank BankFile { get; set; }
     public bool IsFirstRead { get; private set; }
 
-    protected RVBankElement(IRVBank file) : base(file) =>
+    protected RVBankElement(IRVBank file, ILogger? logger) : base(file, logger) =>
         BankFile = file;
 
-    protected RVBankElement(IRVBank file, BisBinaryReader reader, RVBankOptions options) : base(reader, options, file) =>
+    protected RVBankElement(BisBinaryReader reader, RVBankOptions options, IRVBank file, ILogger? logger) : base(reader, options, file, logger) =>
         BankFile = file;
 
     protected override void OnChangesMade(object? sender, EventArgs? e)

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
@@ -23,7 +23,6 @@ public interface IRVBankEntry : IRVBankVfsEntry
 
 public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
 {
-    protected readonly ILogger logger;
 
     private RVBankEntryMime entryMime = RVBankEntryMime.Decompressed;
     public RVBankEntryMime EntryMime
@@ -82,18 +81,17 @@ public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
     }
 
     protected RVBankEntry(
-        ILogger logger,
-        IRVBank file,
-        IRVBankDirectory parent,
         string fileName,
         RVBankEntryMime mime,
         uint originalSize,
         uint offset,
         uint timeStamp,
-        uint dataSize
-    ) : base(file, parent, fileName)
+        uint dataSize,
+        IRVBank file,
+        IRVBankDirectory parent,
+        ILogger? logger
+    ) : base(fileName, file, parent, logger)
     {
-        this.logger = logger;
 
         EntryMime = mime;
         OriginalSize = originalSize;
@@ -103,7 +101,11 @@ public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
     }
 
 
-    protected RVBankEntry(ILogger logger, IRVBank file, IRVBankDirectory parent, BisBinaryReader reader, RVBankOptions options) : base(file, parent, reader, options) => this.logger = logger;
+    protected RVBankEntry(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankDirectory parent,
+        ILogger? logger) : base(reader, options, file, parent, logger)
+    {
+        
+    }
 
     public void Move(IRVBankDirectory destination)
     {

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankProperty.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankProperty.cs
@@ -7,6 +7,7 @@ using Core.Extensions;
 using Entry;
 using FResults;
 using FResults.Extensions;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVBankProperty : IRVBankElement, IBisCloneable<IRVBankProperty>
@@ -42,7 +43,7 @@ public class RVBankProperty : RVBankElement, IRVBankProperty
         }
     }
 
-    public RVBankProperty(IRVBank file, IRVBankVersionEntry parent, string name, string value) : base(file)
+    public RVBankProperty(string name, string value, IRVBank file, IRVBankVersionEntry parent, ILogger? logger) : base(file, logger)
     {
         VersionEntry = parent;
         VersionEntry.ChangesSaved += OnChangesSaved;
@@ -52,7 +53,7 @@ public class RVBankProperty : RVBankElement, IRVBankProperty
         Value = value;
     }
 
-    public RVBankProperty(IRVBank file, IRVBankVersionEntry parent, BisBinaryReader reader, RVBankOptions options) : base(file, reader, options)
+    public RVBankProperty(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankVersionEntry parent, ILogger? logger) : base(reader, options, file, logger)
     {
         VersionEntry = parent;
         VersionEntry.ChangesSaved += OnChangesSaved;

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs
@@ -2,6 +2,7 @@ namespace BisUtils.RVBank.Model.Stubs;
 
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVBankVfsEntry : IRVBankElement
@@ -31,14 +32,14 @@ public abstract class RVBankVfsEntry : RVBankElement, IRVBankVfsEntry
 
     public IRVBankDirectory ParentDirectory { get; protected set; }
 
-    protected RVBankVfsEntry(IRVBank file, IRVBankDirectory parent, string name) : base(file)
+    protected RVBankVfsEntry(string name, IRVBank file, IRVBankDirectory parent, ILogger? logger) : base(file, logger)
     {
         ParentDirectory = parent;
         EntryName = name;
     }
 
-    protected RVBankVfsEntry(IRVBank file, IRVBankDirectory parent, BisBinaryReader reader, RVBankOptions options) :
-        base(file, reader, options) => ParentDirectory = parent;
+    protected RVBankVfsEntry(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankDirectory parent, ILogger? logger) :
+        base(reader, options, file, logger) => ParentDirectory = parent;
 
     public override Result Debinarize(BisBinaryReader reader, RVBankOptions options)
     {

--- a/src/BisUtils.RVShape/Models/Data/RVAnimationPhase.cs
+++ b/src/BisUtils.RVShape/Models/Data/RVAnimationPhase.cs
@@ -9,6 +9,7 @@ using BisUtils.Core.Render.Vector;
 using BisUtils.RVShape.Models.Lod;
 using BisUtils.RVShape.Options;
 using FResults;
+using Microsoft.Extensions.Logging;
 
 public interface IRVAnimationPhase : IBinaryObject<RVShapeOptions>
 {
@@ -23,7 +24,7 @@ public class RVAnimationPhase : BinaryObject<RVShapeOptions>, IRVAnimationPhase
     public List<IVector3D> Points { get; private set; } = null!;
     public float Time { get; set;  }
 
-    public RVAnimationPhase(BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVAnimationPhase(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -31,7 +32,7 @@ public class RVAnimationPhase : BinaryObject<RVShapeOptions>, IRVAnimationPhase
         }
     }
 
-    public RVAnimationPhase(float time, List<IVector3D> points)
+    public RVAnimationPhase(float time, List<IVector3D> points, ILogger? logger) : base(logger)
     {
         Points = points;
         Time = time;

--- a/src/BisUtils.RVShape/Models/Data/RVModelConfig.cs
+++ b/src/BisUtils.RVShape/Models/Data/RVModelConfig.cs
@@ -5,6 +5,7 @@ using BisUtils.Param.Models;
 using BisUtils.Param.Models.Statements;
 using BisUtils.Param.Models.Stubs;
 using BisUtils.Param.Options;
+using Microsoft.Extensions.Logging;
 
 public interface IRVModelConfig : IParamFile
 {
@@ -21,15 +22,15 @@ public class RVModelConfig : ParamFile, IRVModelConfig
     public IParamClass? ModelConfigs { get; }
     public IParamClass? ModelConfig { get; }
 
-    public RVModelConfig(string modelName, List<IParamStatement> statements) : base(modelName, statements)
+    public RVModelConfig(string modelName, List<IParamStatement> statements, ILogger? logger) : base(modelName, statements, logger)
     {
         SkeletonConfigs = null;
         ModelConfigs = null;
         ModelConfig = ModelConfigs is not null ? ModelConfigs >> ModelName : null;
     }
 
-    public RVModelConfig(string modelName, BisBinaryReader reader, ParamOptions options) : base(modelName, reader,
-        options)
+    public RVModelConfig(string modelName, BisBinaryReader reader, ParamOptions options, ILogger? logger) : base(modelName, reader,
+        options, logger)
     {
         SkeletonConfigs = null;
         ModelConfigs = null;

--- a/src/BisUtils.RVShape/Models/Data/RVSharpEdge.cs
+++ b/src/BisUtils.RVShape/Models/Data/RVSharpEdge.cs
@@ -5,6 +5,7 @@ using BisUtils.Core.Extensions;
 using BisUtils.Core.IO;
 using BisUtils.RVShape.Options;
 using FResults;
+using Microsoft.Extensions.Logging;
 
 public interface IRVSharpEdge
 {
@@ -19,6 +20,7 @@ public struct RVSharpEdge : IRVSharpEdge, IBinaryObject<RVShapeOptions>
 {
     public int EdgeX { get; set; }
     public int EdgeY { get; set; }
+    public ILogger? Logger { get; }
 
     public static int CompareEdges(IRVSharpEdge edge0, IRVSharpEdge edge1)
     {
@@ -42,14 +44,16 @@ public struct RVSharpEdge : IRVSharpEdge, IBinaryObject<RVShapeOptions>
 
     public Result? LastResult { get; private set; }
 
-    public RVSharpEdge(int edgeX, int edgeY)
+    public RVSharpEdge(int edgeX, int edgeY, ILogger logger)
     {
         EdgeX = edgeX;
         EdgeY = edgeY;
+        Logger = logger;
     }
 
-    public RVSharpEdge(BisBinaryReader reader, RVShapeOptions options)
+    public RVSharpEdge(BisBinaryReader reader, RVShapeOptions options, ILogger logger)
     {
+        Logger = logger;
         if (!Debinarize(reader, options))
         {
             LastResult!.Throw();
@@ -69,4 +73,5 @@ public struct RVSharpEdge : IRVSharpEdge, IBinaryObject<RVShapeOptions>
         EdgeY = reader.ReadInt32();
         return LastResult = Result.Ok();
     }
+
 }

--- a/src/BisUtils.RVShape/Models/Face/RVFace.cs
+++ b/src/BisUtils.RVShape/Models/Face/RVFace.cs
@@ -9,6 +9,8 @@ using Options;
 using Core.Binarize.Flagging;
 using FResults;
 using FResults.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Utils;
 
 public interface IRVFace : IStrictBinaryObject<RVShapeOptions>, IBisOptionallyFlaggable<RVFaceFlag?>
@@ -29,7 +31,7 @@ public class RVFace : StrictBinaryObject<RVShapeOptions>, IRVFace
     public bool IsExtended => this.IsFlaggable();
     public RVFaceFlag? Flags { get; set; }
 
-    public RVFace(string texture, string? material, List<IRVDataVertex> vertices, params RVFaceFlag[] flags)
+    public RVFace(string texture, string? material, List<IRVDataVertex> vertices, RVFaceFlag[] flags, ILogger? logger) : base(logger)
     {
         Vertices = vertices;
         Texture = texture.ToLower(CultureInfo.CurrentCulture);
@@ -37,12 +39,16 @@ public class RVFace : StrictBinaryObject<RVShapeOptions>, IRVFace
         Flags = BisFlagUtils.CreateFlagsFor<RVFaceFlag>(flags);
     }
 
-    public RVFace()
+    public RVFace(ILogger? logger) : base(logger)
+    {
+
+    }
+    public RVFace() : base(NullLogger.Instance)
     {
 
     }
 
-    public RVFace(BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVFace(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.RVShape/Models/Lod/RVLod.cs
+++ b/src/BisUtils.RVShape/Models/Lod/RVLod.cs
@@ -18,6 +18,8 @@ using Face;
 using FResults;
 using FResults.Extensions;
 using FResults.Reasoning;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public interface IRVLod : IStrictBinaryObject<RVShapeOptions>
 {
@@ -54,11 +56,15 @@ public class RVLod : StrictBinaryObject<RVShapeOptions>, IRVLod
     public IRVSelection? HiddenSelection { get; private set; }
     public IRVSelection? LockedSelection { get; private set; }
 
-    public RVLod()
+    public RVLod() : base(NullLogger.Instance)
     {
     }
 
-    public RVLod(BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVLod(ILogger? logger) : base(logger)
+    {
+    }
+
+    public RVLod(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -72,8 +78,9 @@ public class RVLod : StrictBinaryObject<RVShapeOptions>, IRVLod
         List<IRVPoint> points,
         List<IVector3D> normals,
         List<IRVFace> faces,
-        IRVPointAttrib<float> mass
-    )
+        IRVPointAttrib<float> mass,
+        ILogger? logger
+    ) : base(logger)
     {
         Resolution = resolution;
         Points = points;
@@ -147,7 +154,7 @@ public class RVLod : StrictBinaryObject<RVShapeOptions>, IRVLod
                 throw new NotImplementedException();
             }
         }
-
+        //TODO(MAJOR): LOGGER USAGE IN READINDEXEDLIST ******PLS FIX
         Points = reader
             .ReadIndexedList<RVPoint, IBinarizationOptions>(options, pointCount)
             .Cast<IRVPoint>()
@@ -191,7 +198,7 @@ public class RVLod : StrictBinaryObject<RVShapeOptions>, IRVLod
         //CalculateUVMinMax(out var uvMinMax);
 
         LastResult = ReadLodBody(reader, options);
-        Resolution = new RVResolution(reader, options);
+        Resolution = new RVResolution(reader, options, Logger);
         return LastResult;
     }
 
@@ -421,7 +428,7 @@ public class RVLod : StrictBinaryObject<RVShapeOptions>, IRVLod
                 }
                 case "#Animation#":
                 {
-                    AddAnimationPhase(new RVAnimationPhase(reader, options) { Parent = this });
+                    AddAnimationPhase(new RVAnimationPhase(reader, options, Logger) { Parent = this });
 
                     break;
                 }

--- a/src/BisUtils.RVShape/Models/Point/RVPoint.cs
+++ b/src/BisUtils.RVShape/Models/Point/RVPoint.cs
@@ -6,6 +6,8 @@ using Core.Render.Vector;
 using Options;
 using Core.Binarize.Flagging;
 using FResults;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public interface IRVPoint : IVector3D, IBisFlaggable<RVPointFlag>
 {
@@ -18,12 +20,12 @@ public class RVPoint : BinarizableVector3D, IRVPoint
     public bool IsHidden { get => this.HasFlag(RVPointFlag.SpecialHidden); set => this.AddFlag(RVPointFlag.SpecialHidden); }
 
 
-    public RVPoint(float x, float y, float z, int? flags) : base(x, y, z) => Flags = (RVPointFlag)(flags ?? 0) ;
+    public RVPoint(float x, float y, float z, int? flags, ILogger? logger) : base(x, y, z, logger) => Flags = (RVPointFlag)(flags ?? 0) ;
 
-    public RVPoint(float x, float y, float z, bool hidden) : base(x, y, z) => IsHidden = hidden;
+    public RVPoint(float x, float y, float z, bool hidden, ILogger logger) : base(x, y, z, logger) => IsHidden = hidden;
 
 
-    public RVPoint(BisBinaryReader reader, RVShapeOptions options) : base(reader, options, false)
+    public RVPoint(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, false, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -31,7 +33,12 @@ public class RVPoint : BinarizableVector3D, IRVPoint
         }
     }
 
-    public RVPoint()
+    public RVPoint() : base(NullLogger.Instance)
+    {
+
+    }
+
+    public RVPoint(ILogger? logger) : base(logger)
     {
 
     }

--- a/src/BisUtils.RVShape/Models/RVShape.cs
+++ b/src/BisUtils.RVShape/Models/RVShape.cs
@@ -10,6 +10,7 @@ using Errors;
 using FResults;
 using FResults.Extensions;
 using Lod;
+using Microsoft.Extensions.Logging;
 using Utils;
 
 public interface IRVShape: IStrictBinaryObject<RVShapeOptions>
@@ -81,13 +82,13 @@ public class RVShape : StrictBinaryObject<RVShapeOptions>, IRVShape
         }
     }
 
-    public RVShape(string modelName, List<IRVLod> levelsOfDetail)
+    public RVShape(string modelName, List<IRVLod> levelsOfDetail, ILogger? logger) : base(logger)
     {
         ModelName = modelName;
         LevelsOfDetail = levelsOfDetail;
     }
 
-    public RVShape(string modelName, BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVShape(string modelName, BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         ModelName = modelName;
         if (!Debinarize(reader, options))

--- a/src/BisUtils.RVShape/Models/Utils/RVDataVertex.cs
+++ b/src/BisUtils.RVShape/Models/Utils/RVDataVertex.cs
@@ -7,6 +7,8 @@ using Core.IO;
 using Data;
 using Options;
 using FResults;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public interface IRVDataVertex : IBinaryObject<RVShapeOptions>, IRVUvMap
 {
@@ -23,7 +25,7 @@ public class RVDataVertex : BinaryObject<RVShapeOptions>, IRVDataVertex
     public float MapV { get; set;  }
     public IRVUvMap? FaceUV { get; set; }
 
-    public RVDataVertex(int point, int normal, float mapU, float mapV, IRVUvMap? uvMap)
+    public RVDataVertex(int point, int normal, float mapU, float mapV, IRVUvMap? uvMap, ILogger? logger) : base(logger)
     {
         FaceUV = uvMap;
         Point = point;
@@ -32,12 +34,17 @@ public class RVDataVertex : BinaryObject<RVShapeOptions>, IRVDataVertex
         MapV = mapV;
     }
 
-    public RVDataVertex()
+    public RVDataVertex(ILogger? logger) : base(logger)
     {
 
     }
 
-    public RVDataVertex(BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVDataVertex() : base(NullLogger.Instance)
+    {
+
+    }
+
+    public RVDataVertex(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {

--- a/src/BisUtils.RVShape/Models/Utils/RVResolution.cs
+++ b/src/BisUtils.RVShape/Models/Utils/RVResolution.cs
@@ -9,6 +9,8 @@ using BisUtils.Core.IO;
 using BisUtils.RVShape.Options;
 using FResults;
 using Lod;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public interface IRVResolution : IBinaryObject<RVShapeOptions>
 {
@@ -47,9 +49,9 @@ public sealed class RVResolution : BinaryObject<RVShapeOptions>, IRVResolution
     public bool IsShadow { get; private set; }
     public bool IsVisual { get; private set; }
 
-    public RVResolution(float value) => Value = value;
+    public RVResolution(float value, ILogger? logger) : base(logger) => Value = value;
 
-    public RVResolution(BisBinaryReader reader, RVShapeOptions options) : base(reader, options)
+    public RVResolution(BisBinaryReader reader, RVShapeOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -58,7 +60,7 @@ public sealed class RVResolution : BinaryObject<RVShapeOptions>, IRVResolution
     }
 
     public static implicit operator float(RVResolution resolution) => resolution.Value;
-    public static explicit operator RVResolution(float resolution) => new(resolution);
+    public static explicit operator RVResolution(float resolution) => new(resolution, NullLogger.Instance);
 
     private static string GetLodName(float value, RVLodType? type = null)
     {

--- a/src/BisUtils.RVTexture/Models/RVPalette.cs
+++ b/src/BisUtils.RVTexture/Models/RVPalette.cs
@@ -6,6 +6,7 @@ using Core.Extensions;
 using Core.IO;
 using Core.Render.Color;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVPalette : IBinaryObject<RVTextureOptions>
@@ -26,7 +27,7 @@ public class RVPalette : BinaryObject<RVTextureOptions>, IRVPalette
     public bool IsAlpha { get; set; }
     public bool IsTransparent { get; set; }
 
-    public RVPalette(BisBinaryReader reader, RVTextureOptions options) : base(reader, options)
+    public RVPalette(BisBinaryReader reader, RVTextureOptions options, ILogger? logger) : base(reader, options, logger)
     {
         if (!Debinarize(reader, options))
         {
@@ -34,7 +35,7 @@ public class RVPalette : BinaryObject<RVTextureOptions>, IRVPalette
         }
     }
 
-    public RVPalette(IColor maxColor, IColor averageColor, List<IColor> colors, bool isAlpha, bool isTransparent)
+    public RVPalette(IColor maxColor, IColor averageColor, List<IColor> colors, bool isAlpha, bool isTransparent, ILogger? logger) : base(logger)
     {
         MaxColor = maxColor;
         AverageColor = averageColor;

--- a/src/BisUtils.RVTexture/Models/RVTexture.cs
+++ b/src/BisUtils.RVTexture/Models/RVTexture.cs
@@ -2,8 +2,10 @@
 
 using Core.Binarize;
 using Core.Binarize.Implementation;
+using Core.Extensions;
 using Core.IO;
 using FResults;
+using Microsoft.Extensions.Logging;
 using Options;
 
 public interface IRVTexture : IBinaryObject<RVTextureOptions>
@@ -13,7 +15,21 @@ public interface IRVTexture : IBinaryObject<RVTextureOptions>
 
 public class RVTexture : BinaryObject<RVTextureOptions>, IRVTexture
 {
+    public RVTexture(BisBinaryReader reader, RVTextureOptions options, ILogger? logger) : base(reader, options, logger)
+    {
+        if (!Debinarize(reader, options))
+        {
+            LastResult!.Throw();
+        }
+    }
+
+    public RVTexture(ILogger? logger) : base(logger)
+    {
+    }
+
     public override Result Binarize(BisBinaryWriter writer, RVTextureOptions options) => throw new NotImplementedException();
 
-    public override Result Debinarize(BisBinaryReader reader, RVTextureOptions options) => throw new NotImplementedException();
+    public sealed override Result Debinarize(BisBinaryReader reader, RVTextureOptions options) => throw new NotImplementedException();
+
+
 }

--- a/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs
+++ b/test/BisUtils.Bank.Benchmarks/PboFileBinarizationBenchmarks.cs
@@ -16,7 +16,7 @@ public class PboFileBinarizationBenchmarks
         using var fs = File.OpenRead(@"C:\Steam\steamapps\common\DayZ\Addons\weapons_data.pbo");
         using var reader = new BisBinaryReader(fs);
 
-        pbo = new RVBank(logger, "weapons_data", reader, new());
+        pbo = new RVBank("weapons_data", reader, new(), null, logger);
 
         destination = new BisBinaryWriter(new MemoryStream((int)fs.Length));
     }

--- a/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
+++ b/test/BisUtils.Bank.Benchmarks/PboFileCreationBenchmarks.cs
@@ -25,13 +25,13 @@ public class PboFileCreationBenchmarks
     public void DebinarizeFlatReadSetup() => reader.BaseStream.Position = 0;
 
     [Benchmark(Baseline = true)]
-    public RVBank DebinarizeFlatRead() => new(logger,"structures_data", reader, flatReadOptions);
+    public RVBank DebinarizeFlatRead() => new("structures_data", reader, flatReadOptions, null, logger);
 
     [IterationSetup(Target = nameof(Debinarize))]
     public void DebinarizeSetup() => reader.BaseStream.Position = 0;
 
     [Benchmark]
-    public RVBank Debinarize() => new(logger, "structures_data", reader, options);
+    public RVBank Debinarize() => new("structures_data", reader, options, null, logger);
 
     [GlobalCleanup]
     public void Cleanup() => reader.Close();

--- a/test/Scratches/ParamTest/Program.cs
+++ b/test/Scratches/ParamTest/Program.cs
@@ -3,13 +3,15 @@
 using BisUtils.Core.Binarize.Flagging;
 using BisUtils.Param.Models;
 using BisUtils.Param.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 public class Foo
 {
     public static void Main()
     {
         var config = File.OpenRead(@"C:\Program Files (x86)\Steam\steamapps\common\DayZ Tools\Bin\CfgConvert\config.cpp");
-        var param = ParamFile.ReadParamFile("config", config, new ParamOptions());
+        var param = ParamFile.ReadParamFile("config", config, new ParamOptions(), NullLogger.Instance);
 
     }
 }

--- a/test/Scratches/ShapeTest/Program.cs
+++ b/test/Scratches/ShapeTest/Program.cs
@@ -3,8 +3,9 @@
 using BisUtils.Core.IO;
 using BisUtils.RVShape.Models;
 using BisUtils.RVShape.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 
 var reader = new BisBinaryReader(File.OpenRead(@"C:\Users\ryann\Desktop\breachingcharge.p3d"));
 var shapeOptions = new RVShapeOptions();
-var shape = new RVShape("breachingcharge", reader, shapeOptions);
+var shape = new RVShape("breachingcharge", reader, shapeOptions, NullLogger.Instance);
 Console.WriteLine("Done");


### PR DESCRIPTION
As of today there was no actual way for me to adequately log any issues/problems without creating a sloppy print statement or a secondary project. All good libraries should have support for almost all logging libraries through a facade, and BisUtils is no exception. This first commit adds a new 'IBisLoggable' interface which allows objects to own and keep track of their logger. I have extended this contract in the BinaryObject abstraction to make logging a breeze in binary formats. I previously made the goal to use no external libraries, and although that is still the case I feel like the addition of "Microsoft.Extensions.Logging.Abstraction" to BisUtils.Core is a good choice as this is the language standard.

TODO:
- Log FResult warnings in IBisLoggable Objects
- Fix 'ReadIndexedList' aswell as any other functions that dynamically create an instance of 'BinaryObject<?>' as they currently don't implement logger support.