### PR TITLE
(Bank): Fix Major Bugs/Issues In RVBank.

### DIFF
--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -12,8 +12,13 @@
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -172,7 +177,7 @@
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
       <workItem from="1690316514893" duration="6136000" />
-      <workItem from="1690383860142" duration="1922000" />
+      <workItem from="1690383860142" duration="4267000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -310,7 +315,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690322160548</updated>
     </task>
-    <option name="localTasksCounter" value="18" />
+    <task id="LOCAL-00018" summary="fix(bank): Rewrite DirectoryExtensions">
+      <option name="closed" value="true" />
+      <created>1690385840705</created>
+      <option name="number" value="00018" />
+      <option name="presentableId" value="LOCAL-00018" />
+      <option name="project" value="LOCAL" />
+      <updated>1690385840706</updated>
+    </task>
+    <option name="localTasksCounter" value="19" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -359,7 +372,8 @@
     <MESSAGE value="feat(bank): Work On Duplicate Entries" />
     <MESSAGE value="feat(bank): Refactor RVBank &amp; RVBankDirectoryExtensions: Clean-up and Optimization. RVBankDirectoryExtensions needs some MAJOR fixes - has been giving me a headache&#10;&#10;The `RVBank.cs` and `RVBankDirectoryExtensions.cs` have been deeply refactored to improve readability, and optimize performance by minimizing excess operations during binarization and debinarization.  &#10;Log messages about the start and end of debinarization were removed from the `RVBank.cs`.&#10;Also, an addition of bank test project was made to the solution file `BisUtils.sln` while the `BisCompatibleLZSS.cs` class now decodes and compresses using encoding UTF8 and returns byte arrays.&#10;&#10;These changes are necessary to improve the performance of data debinarization and binarization, and ultimately enhance the overall efficiency of the project." />
     <MESSAGE value="chore(bank): Add BankTest Project" />
-    <option name="LAST_COMMIT_MESSAGE" value="chore(bank): Add BankTest Project" />
+    <MESSAGE value="fix(bank): Rewrite DirectoryExtensions" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Rewrite DirectoryExtensions" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -395,44 +409,33 @@
           <line>36</line>
           <properties documentPath="E:\projects\csharp\BisUtils\test\Scratches\BankTest\Program.cs" initialLine="37" containingFunctionPresentation="">
             <startOffsets>
-              <option value="1268" />
+              <option value="1290" />
             </startOffsets>
             <endOffsets>
-              <option value="1288" />
+              <option value="1310" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="8" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
-          <line>239</line>
-          <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="240" containingFunctionPresentation="Method 'Binarize'">
-            <startOffsets>
-              <option value="7788" />
-            </startOffsets>
-            <endOffsets>
-              <option value="7822" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="17" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
           <line>237</line>
-          <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="238" containingFunctionPresentation="Method 'Binarize'">
+          <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="237" containingFunctionPresentation="Method 'Binarize'">
             <startOffsets>
-              <option value="7644" />
+              <option value="7744" />
             </startOffsets>
             <endOffsets>
-              <option value="7720" />
+              <option value="7771" />
             </endOffsets>
           </properties>
-          <option name="timeStamp" value="20" />
+          <option name="timeStamp" value="25" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>
     <pin-to-top-manager>
       <pinned-members>
+        <PinnedItemInfo parentTag="Type#BisUtils.Core.Binarize.Implementation.BinaryObject`1" memberName="Logger" />
+        <PinnedItemInfo parentTag="Type#BisUtils.Core.Binarize.Synchronization.BisSynchronizable`1" memberName="SynchronizationStream" />
         <PinnedItemInfo parentTag="Type#BisUtils.RVBank.Model.RVBank" memberName="PboEntries" />
       </pinned-members>
     </pin-to-top-manager>

--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -12,11 +12,8 @@
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/IO/BisBinaryWriter.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/IO/BisBinaryWriter.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -174,7 +171,7 @@
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
       <workItem from="1690316514893" duration="6136000" />
-      <workItem from="1690383860142" duration="8194000" />
+      <workItem from="1690383860142" duration="8999000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -344,7 +341,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690390125975</updated>
     </task>
-    <option name="localTasksCounter" value="22" />
+    <task id="LOCAL-00022" summary="fix(bank): Fix RVBankDirectory::CalculateLength">
+      <option name="closed" value="true" />
+      <created>1690392206287</created>
+      <option name="number" value="00022" />
+      <option name="presentableId" value="LOCAL-00022" />
+      <option name="project" value="LOCAL" />
+      <updated>1690392206287</updated>
+    </task>
+    <option name="localTasksCounter" value="23" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -397,6 +402,8 @@
     <MESSAGE value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
     <MESSAGE value="fix(bank): Fix RVBankEntry::Move" />
     <MESSAGE value="fix(bank): Write Path Instead Of Name" />
+    <MESSAGE value="fix(bank): Fix RVBankDirectory::CalculateLength" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Fix RVBankDirectory::CalculateLength" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -442,13 +449,13 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
-          <line>237</line>
+          <line>233</line>
           <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="237" containingFunctionPresentation="Method 'Binarize'">
             <startOffsets>
-              <option value="7786" />
+              <option value="7594" />
             </startOffsets>
             <endOffsets>
-              <option value="7878" />
+              <option value="7686" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="31" />

--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -10,7 +10,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="" />
+    <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -166,7 +171,8 @@
       <workItem from="1690216527563" duration="920000" />
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
-      <workItem from="1690316514893" duration="5454000" />
+      <workItem from="1690316514893" duration="6136000" />
+      <workItem from="1690383860142" duration="1922000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -296,7 +302,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690322069935</updated>
     </task>
-    <option name="localTasksCounter" value="17" />
+    <task id="LOCAL-00017" summary="chore(bank): Add BankTest Project">
+      <option name="closed" value="true" />
+      <created>1690322160548</created>
+      <option name="number" value="00017" />
+      <option name="presentableId" value="LOCAL-00017" />
+      <option name="project" value="LOCAL" />
+      <updated>1690322160548</updated>
+    </task>
+    <option name="localTasksCounter" value="18" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -344,7 +358,8 @@
     <MESSAGE value="feat(logging): Add logging infrastructure to the BisUtils project via 'IBisLoggable' and 'IBinaryObject'" />
     <MESSAGE value="feat(bank): Work On Duplicate Entries" />
     <MESSAGE value="feat(bank): Refactor RVBank &amp; RVBankDirectoryExtensions: Clean-up and Optimization. RVBankDirectoryExtensions needs some MAJOR fixes - has been giving me a headache&#10;&#10;The `RVBank.cs` and `RVBankDirectoryExtensions.cs` have been deeply refactored to improve readability, and optimize performance by minimizing excess operations during binarization and debinarization.  &#10;Log messages about the start and end of debinarization were removed from the `RVBank.cs`.&#10;Also, an addition of bank test project was made to the solution file `BisUtils.sln` while the `BisCompatibleLZSS.cs` class now decodes and compresses using encoding UTF8 and returns byte arrays.&#10;&#10;These changes are necessary to improve the performance of data debinarization and binarization, and ultimately enhance the overall efficiency of the project." />
-    <option name="LAST_COMMIT_MESSAGE" value="feat(bank): Refactor RVBank &amp; RVBankDirectoryExtensions: Clean-up and Optimization. RVBankDirectoryExtensions needs some MAJOR fixes - has been giving me a headache&#10;&#10;The `RVBank.cs` and `RVBankDirectoryExtensions.cs` have been deeply refactored to improve readability, and optimize performance by minimizing excess operations during binarization and debinarization.  &#10;Log messages about the start and end of debinarization were removed from the `RVBank.cs`.&#10;Also, an addition of bank test project was made to the solution file `BisUtils.sln` while the `BisCompatibleLZSS.cs` class now decodes and compresses using encoding UTF8 and returns byte arrays.&#10;&#10;These changes are necessary to improve the performance of data debinarization and binarization, and ultimately enhance the overall efficiency of the project." />
+    <MESSAGE value="chore(bank): Add BankTest Project" />
+    <option name="LAST_COMMIT_MESSAGE" value="chore(bank): Add BankTest Project" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -377,55 +392,42 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/test/Scratches/BankTest/Program.cs</url>
-          <line>37</line>
+          <line>36</line>
           <properties documentPath="E:\projects\csharp\BisUtils\test\Scratches\BankTest\Program.cs" initialLine="37" containingFunctionPresentation="">
             <startOffsets>
-              <option value="1286" />
+              <option value="1268" />
             </startOffsets>
             <endOffsets>
-              <option value="1306" />
+              <option value="1288" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="8" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
-          <line>240</line>
+          <line>239</line>
           <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="240" containingFunctionPresentation="Method 'Binarize'">
             <startOffsets>
-              <option value="7743" />
+              <option value="7788" />
             </startOffsets>
             <endOffsets>
-              <option value="7777" />
+              <option value="7822" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="17" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
-          <line>238</line>
+          <line>237</line>
           <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="238" containingFunctionPresentation="Method 'Binarize'">
             <startOffsets>
-              <option value="7622" />
+              <option value="7644" />
             </startOffsets>
             <endOffsets>
-              <option value="7675" />
+              <option value="7720" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="20" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs</url>
-          <line>36</line>
-          <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Extensions\RVBankDirectoryExtensions.cs" initialLine="36" containingFunctionPresentation="Method 'GetFileEntries'">
-            <startOffsets>
-              <option value="1091" />
-            </startOffsets>
-            <endOffsets>
-              <option value="1132" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="21" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -12,8 +12,9 @@
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/RVPathUtilities.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/RVPathUtilities.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -171,7 +172,7 @@
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
       <workItem from="1690316514893" duration="6136000" />
-      <workItem from="1690383860142" duration="5384000" />
+      <workItem from="1690383860142" duration="6152000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -325,7 +326,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690388397052</updated>
     </task>
-    <option name="localTasksCounter" value="20" />
+    <task id="LOCAL-00020" summary="fix(bank): Fix RVBankEntry::Move">
+      <option name="closed" value="true" />
+      <created>1690389413207</created>
+      <option name="number" value="00020" />
+      <option name="presentableId" value="LOCAL-00020" />
+      <option name="project" value="LOCAL" />
+      <updated>1690389413207</updated>
+    </task>
+    <option name="localTasksCounter" value="21" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -376,7 +385,8 @@
     <MESSAGE value="chore(bank): Add BankTest Project" />
     <MESSAGE value="fix(bank): Rewrite DirectoryExtensions" />
     <MESSAGE value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
-    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
+    <MESSAGE value="fix(bank): Fix RVBankEntry::Move" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Fix RVBankEntry::Move" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -12,14 +12,8 @@
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/RVPathUtilities.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/Parsing/RVPathUtilities.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -177,7 +171,7 @@
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
       <workItem from="1690316514893" duration="6136000" />
-      <workItem from="1690383860142" duration="4267000" />
+      <workItem from="1690383860142" duration="5384000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -323,7 +317,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690385840706</updated>
     </task>
-    <option name="localTasksCounter" value="19" />
+    <task id="LOCAL-00019" summary="fix(bank): Fix Entry Length Calculation; Fix Extensions">
+      <option name="closed" value="true" />
+      <created>1690388397052</created>
+      <option name="number" value="00019" />
+      <option name="presentableId" value="LOCAL-00019" />
+      <option name="project" value="LOCAL" />
+      <updated>1690388397052</updated>
+    </task>
+    <option name="localTasksCounter" value="20" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -373,7 +375,8 @@
     <MESSAGE value="feat(bank): Refactor RVBank &amp; RVBankDirectoryExtensions: Clean-up and Optimization. RVBankDirectoryExtensions needs some MAJOR fixes - has been giving me a headache&#10;&#10;The `RVBank.cs` and `RVBankDirectoryExtensions.cs` have been deeply refactored to improve readability, and optimize performance by minimizing excess operations during binarization and debinarization.  &#10;Log messages about the start and end of debinarization were removed from the `RVBank.cs`.&#10;Also, an addition of bank test project was made to the solution file `BisUtils.sln` while the `BisCompatibleLZSS.cs` class now decodes and compresses using encoding UTF8 and returns byte arrays.&#10;&#10;These changes are necessary to improve the performance of data debinarization and binarization, and ultimately enhance the overall efficiency of the project." />
     <MESSAGE value="chore(bank): Add BankTest Project" />
     <MESSAGE value="fix(bank): Rewrite DirectoryExtensions" />
-    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Rewrite DirectoryExtensions" />
+    <MESSAGE value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/.idea.BisUtils/.idea/workspace.xml
+++ b/.idea/.idea.BisUtils/.idea/workspace.xml
@@ -12,9 +12,11 @@
   <component name="ChangeListManager">
     <list default="true" id="730c2967-dd54-42ba-b571-662f852de5c4" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.BisUtils/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.Core/IO/BisBinaryWriter.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.Core/IO/BisBinaryWriter.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/Scratches/BankTest/Program.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -32,12 +34,12 @@
   </component>
   <component name="HighlightingSettingsPerFile">
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/35dda6186b16a39ac1162d64ecf0c27b8ebe94f2af6f7ce3b8e9e84698f06c37/LoggerMessage.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/3ab621a475ad1855b32c8fb94315b33ee28b6996ed15846c8c5651a4fd81dbb1/Sum.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/3d5314c4b5f391de6f26e7ce0d430d6d2aa1d7a44530b874fdbb1a4a97374/File.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/6b328b91f273b497721dcead23dabd813c6a99f9c5613a78ea1cee575b273b/Stream.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/9a6b1457cbcf17db31a383ba49ef9bcc786cf3ef77146d997eee499b27a46d/Object.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzCfgMod.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/BisUtils.DZConfig/Models/DzPathCtx.cs" root0="FORCE_HIGHLIGHTING" />
-    <setting file="mock://E:/projects/csharp/BisUtils/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" root0="SKIP_HIGHLIGHTING" />
-    <setting file="mock://E:/projects/csharp/BisUtils/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs" root0="SKIP_HIGHLIGHTING" />
   </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
@@ -172,7 +174,7 @@
       <workItem from="1690293944544" duration="10847000" />
       <workItem from="1690313313597" duration="365000" />
       <workItem from="1690316514893" duration="6136000" />
-      <workItem from="1690383860142" duration="6152000" />
+      <workItem from="1690383860142" duration="8194000" />
     </task>
     <task id="LOCAL-00001" summary="feat(bank): Add Support For Moving Directories">
       <option name="closed" value="true" />
@@ -334,7 +336,15 @@
       <option name="project" value="LOCAL" />
       <updated>1690389413207</updated>
     </task>
-    <option name="localTasksCounter" value="21" />
+    <task id="LOCAL-00021" summary="fix(bank): Write Path Instead Of Name">
+      <option name="closed" value="true" />
+      <created>1690390125975</created>
+      <option name="number" value="00021" />
+      <option name="presentableId" value="LOCAL-00021" />
+      <option name="project" value="LOCAL" />
+      <updated>1690390125975</updated>
+    </task>
+    <option name="localTasksCounter" value="22" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -386,7 +396,7 @@
     <MESSAGE value="fix(bank): Rewrite DirectoryExtensions" />
     <MESSAGE value="fix(bank): Fix Entry Length Calculation; Fix Extensions" />
     <MESSAGE value="fix(bank): Fix RVBankEntry::Move" />
-    <option name="LAST_COMMIT_MESSAGE" value="fix(bank): Fix RVBankEntry::Move" />
+    <MESSAGE value="fix(bank): Write Path Instead Of Name" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -419,29 +429,29 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/test/Scratches/BankTest/Program.cs</url>
-          <line>36</line>
-          <properties documentPath="E:\projects\csharp\BisUtils\test\Scratches\BankTest\Program.cs" initialLine="37" containingFunctionPresentation="">
+          <line>41</line>
+          <properties documentPath="E:\projects\csharp\BisUtils\test\Scratches\BankTest\Program.cs" initialLine="41" containingFunctionPresentation="">
             <startOffsets>
-              <option value="1290" />
+              <option value="1399" />
             </startOffsets>
             <endOffsets>
-              <option value="1310" />
+              <option value="1476" />
             </endOffsets>
           </properties>
-          <option name="timeStamp" value="8" />
+          <option name="timeStamp" value="27" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="DotNet Breakpoints">
           <url>file://$PROJECT_DIR$/src/BisUtils.RVBank/Model/RVBank.cs</url>
           <line>237</line>
           <properties documentPath="E:\projects\csharp\BisUtils\src\BisUtils.RVBank\Model\RVBank.cs" initialLine="237" containingFunctionPresentation="Method 'Binarize'">
             <startOffsets>
-              <option value="7744" />
+              <option value="7786" />
             </startOffsets>
             <endOffsets>
-              <option value="7771" />
+              <option value="7878" />
             </endOffsets>
           </properties>
-          <option name="timeStamp" value="25" />
+          <option name="timeStamp" value="31" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs
+++ b/src/BisUtils.Core/Binarize/Synchronization/BisSynchronizable.cs
@@ -82,6 +82,7 @@ public abstract class BisSynchronizable<TOptions> : StrictBinaryObject<TOptions>
         if (SynchronizationStream is { } stream)
         {
             var writer = new BisBinaryWriter(stream, options.Charset, true);
+            writer.Seek(0, SeekOrigin.Begin);
             LastResult = Binarize(writer, options);
         }
 

--- a/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs
+++ b/src/BisUtils.Core/Compression/BisCompatibleLZSS.cs
@@ -105,7 +105,7 @@ public sealed class BisCompatibleLzss
 
     }
 
-    public Stream Encode(Stream inputStream, out uint outputSize)
+    public byte[] Encode(Stream inputStream, out uint outputSize)
     {
         if (!inputStream.CanRead)
         {
@@ -121,7 +121,7 @@ public sealed class BisCompatibleLzss
         outputSize = Encode(memoryStream.ToArray(), binaryWriter);
 
         encodedStream.Seek(0, SeekOrigin.Begin);
-        return encodedStream;
+        return encodedStream.ToArray();
     }
 
     public uint Encode(Stream inputStream, BinaryWriter output)

--- a/src/BisUtils.Core/IO/BisBinaryWriter.cs
+++ b/src/BisUtils.Core/IO/BisBinaryWriter.cs
@@ -21,8 +21,7 @@ public class BisBinaryWriter : BinaryWriter
 
     public void WriteAsciiZ(string str, Encoding encoding)
     {
-        var bytes = encoding.GetBytes(str);
-        Write(bytes, 0, bytes.Length);
+        Write(encoding.GetBytes(str));
         Write((byte)0); // Null-terminate the string
     }
 

--- a/src/BisUtils.Core/Parsing/RVPathUtilities.cs
+++ b/src/BisUtils.Core/Parsing/RVPathUtilities.cs
@@ -40,8 +40,8 @@ public static class RVPathUtilities
         return new string(result, 0, charsWritten);
     }
 
-    public static string GetFilename(string path) =>
-        path.Remove(0, path.LastIndexOf('\\') + 1);
+    public static string GetFilename(string path) =>  path.Split('\\')[^1];
+
 
     public static string GetParent(string path) =>
         path.Remove(path.LastIndexOf('\\') + 1);

--- a/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs
+++ b/src/BisUtils.RVBank/Extensions/RVBankDirectoryExtensions.cs
@@ -187,8 +187,29 @@ public static class RVBankDirectoryExtensions
         RVBankDataType packingMethod
     ) => ctx.PboEntries.Add(new RVBankDataEntry(fileName, mime, offset, timeStamp, data, packingMethod, ctx.BankFile, ctx, logger));
 
-    public static void RemoveEntry(this IRVBankDirectory ctx, IRVBankEntry entry) => ctx.PboEntries.Remove(entry);
+    public static void RemoveEntry(this IRVBankDirectory ctx, IRVBankEntry entry)
+    {
+        ctx.PboEntries.Remove(entry);
+        if (ctx.IsEmpty())
+        {
+            ctx.ParentDirectory.RemoveDirectory(ctx);
+        }
+    }
 
-    public static void RemoveDirectory(this IRVBankDirectory ctx, IRVBankDirectory directory) => ctx.PboEntries.Remove(directory);
+    public static void RemoveDirectory(this IRVBankDirectory ctx, IRVBankDirectory directory)
+    {
+        while (true)
+        {
+            ctx.PboEntries.Remove(directory);
+            if (ctx.IsEmpty())
+            {
+                var ctx1 = ctx;
+                ctx = ctx.ParentDirectory;
+                directory = ctx1;
+                continue;
+            }
 
+            break;
+        }
+    }
 }

--- a/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
+++ b/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
@@ -1,5 +1,6 @@
 namespace BisUtils.RVBank.Model.Entry;
 
+using System.Text;
 using Alerts.Errors;
 using Core.Binarize.Exceptions;
 using Core.IO;
@@ -206,13 +207,12 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
 
     public sealed override Result Binarize(BisBinaryWriter writer, RVBankOptions options)
     {
-        writer.Write(Path);
-        writer.Write((long)EntryMime);
+        writer.WriteAsciiZ(Path, options);
+        writer.Write((uint)EntryMime);
         writer.Write(OriginalSize);
         writer.Write(Offset);
         writer.Write(TimeStamp);
         writer.Write(DataSize);
-        PackingMethod = AssumePackingMethod();
         return LastResult = Result.Ok();
     }
 

--- a/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
+++ b/src/BisUtils.RVBank/Model/Entry/RVBankDataEntry.cs
@@ -206,14 +206,14 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
 
     public sealed override Result Binarize(BisBinaryWriter writer, RVBankOptions options)
     {
-        LastResult = base.Binarize(writer, options);
+        writer.Write(Path);
         writer.Write((long)EntryMime);
         writer.Write(OriginalSize);
         writer.Write(Offset);
         writer.Write(TimeStamp);
         writer.Write(DataSize);
         PackingMethod = AssumePackingMethod();
-        return LastResult;
+        return LastResult = Result.Ok();
     }
 
     internal void SetEntryDataQuietly(Stream data) => entryData = data;
@@ -292,5 +292,5 @@ public class RVBankDataEntry : RVBankEntry, IRVBankDataEntry
         return LastResult;
     }
 
-    public override uint CalculateLength(RVBankOptions options) =>  21 + (uint) options.Charset.GetByteCount(EntryName);
+    public override uint CalculateLength(RVBankOptions options) =>  21 + (uint) options.Charset.GetByteCount(Path);
 }

--- a/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs
+++ b/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs
@@ -100,7 +100,16 @@ public class RVBankVersionEntry : RVBankEntry, IRVBankVersionEntry
         return LastResult;
     }
 
-    public sealed override Result Binarize(BisBinaryWriter writer, RVBankOptions options) => LastResult = base.Binarize(writer, options).WithReasons(WritePboProperties(writer, options).Reasons);
+    public sealed override Result Binarize(BisBinaryWriter writer, RVBankOptions options)
+    {
+        writer.WriteAsciiZ(EntryName, options);
+        writer.Write((int)EntryMime);
+        writer.Write(OriginalSize);
+        writer.Write(Offset);
+        writer.Write(TimeStamp);
+        writer.Write(DataSize);
+        return WritePboProperties(writer, options);
+    }
 
 
     public sealed override Result Debinarize(BisBinaryReader reader, RVBankOptions options)
@@ -145,8 +154,7 @@ public class RVBankVersionEntry : RVBankEntry, IRVBankVersionEntry
 
         return LastResult;
     }
-
-    public new long CalculateLength(RVBankOptions options) => base.CalculateLength(options) + 1 + Properties.Sum(property =>
+    public override uint CalculateLength(RVBankOptions options) =>  (uint) (21 + options.Charset.GetByteCount(EntryName)) + 1 +  (uint)Properties.Sum(property =>
         2 + options.Charset.GetByteCount(property.Name) + options.Charset.GetByteCount(property.Value));
 
     public IRVBankProperty CreateVersionProperty(string name, string value) => new RVBankProperty(name, value, BankFile, this, Logger);

--- a/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs
+++ b/src/BisUtils.RVBank/Model/Entry/RVBankVersionEntry.cs
@@ -102,7 +102,7 @@ public class RVBankVersionEntry : RVBankEntry, IRVBankVersionEntry
 
     public sealed override Result Binarize(BisBinaryWriter writer, RVBankOptions options)
     {
-        writer.WriteAsciiZ(EntryName, options);
+        writer.WriteAsciiZ(Path, options);
         writer.Write((int)EntryMime);
         writer.Write(OriginalSize);
         writer.Write(Offset);
@@ -154,7 +154,7 @@ public class RVBankVersionEntry : RVBankEntry, IRVBankVersionEntry
 
         return LastResult;
     }
-    public override uint CalculateLength(RVBankOptions options) =>  (uint) (21 + options.Charset.GetByteCount(EntryName)) + 1 +  (uint)Properties.Sum(property =>
+    public override uint CalculateLength(RVBankOptions options) =>  (uint) (21 + options.Charset.GetByteCount(Path)) + 1 +  (uint)Properties.Sum(property =>
         2 + options.Charset.GetByteCount(property.Name) + options.Charset.GetByteCount(property.Value));
 
     public IRVBankProperty CreateVersionProperty(string name, string value) => new RVBankProperty(name, value, BankFile, this, Logger);

--- a/src/BisUtils.RVBank/Model/RVBank.cs
+++ b/src/BisUtils.RVBank/Model/RVBank.cs
@@ -178,6 +178,7 @@ public class RVBank : BisSynchronizable<RVBankOptions>, IRVBank
             }
             else if (!entry.InitializeData(reader, options))
             {
+                Logger?.LogCritical("There was a critical error while decompressing '{EntryName}', Saving compressed data.", entry.EntryName);
                 markedForRemoval.Add(entry);
             }
         }
@@ -247,6 +248,7 @@ public class RVBank : BisSynchronizable<RVBankOptions>, IRVBank
             entry.Binarize(writer, options);
         }
         writer.BaseStream.Seek(dataEnd, SeekOrigin.Begin);
+        writer.Write((byte)0);
         var digest = CalculateDigest(writer.BaseStream);
         digest.Write(writer);
         return LastResult!;

--- a/src/BisUtils.RVBank/Model/RVBank.cs
+++ b/src/BisUtils.RVBank/Model/RVBank.cs
@@ -183,10 +183,6 @@ public class RVBank : BisSynchronizable<RVBankOptions>, IRVBank
             }
         }
 
-        foreach (var directory in this.GetDirectories().ToList().Where(directory => directory.IsEmpty()))
-        {
-            directory.ParentDirectory.RemoveDirectory(directory);
-        }
         Logger?.LogDebug("Data sweep ended at {Pos}. {IgnoreCount} entry(s) were skipped to avoid the extraction of unused data.", reader.BaseStream.Position, markedForRemoval.Count);
 
         Logger?.LogDebug("Removing deleted/stale entries from the directory structure.");

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankDirectory.cs
@@ -80,5 +80,5 @@ public class RVBankDirectory : RVBankVfsEntry, IRVBankDirectory
         OnChangesMade(this, EventArgs.Empty);
     }
 
-    public uint CalculateLength(RVBankOptions options) => 0;
+    public uint CalculateLength(RVBankOptions options) => (uint) pboEntries.Sum(it => it.CalculateLength(options));
 }

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
@@ -104,7 +104,7 @@ public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
     protected RVBankEntry(BisBinaryReader reader, RVBankOptions options, IRVBank file, IRVBankDirectory parent,
         ILogger? logger) : base(reader, options, file, parent, logger)
     {
-        
+
     }
 
     public void Move(IRVBankDirectory destination)
@@ -123,6 +123,5 @@ public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
         OriginalSize == 0 && Offset == 0 && TimeStamp == 0 && DataSize == 0;
 
     public bool IsDummyEntry() => IsEmptyMeta() && EntryName == "";
-
-    public uint CalculateLength(RVBankOptions options) => (uint)(21 + options.Charset.GetByteCount(EntryName));
+    public abstract uint CalculateLength(RVBankOptions options);
 }

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankEntry.cs
@@ -116,6 +116,7 @@ public abstract class RVBankEntry : RVBankVfsEntry, IRVBankEntry
 
         ParentDirectory.RemoveEntry(this);
         ParentDirectory = destination;
+        destination.PboEntries.Add(this);
         OnChangesMade(this, EventArgs.Empty);
     }
 

--- a/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs
+++ b/src/BisUtils.RVBank/Model/Stubs/RVBankVfsEntry.cs
@@ -26,8 +26,8 @@ public abstract class RVBankVfsEntry : RVBankElement, IRVBankVfsEntry
         }
     }
 
-    public string Path => ParentDirectory is { } parentDirectory ? parentDirectory.Path + "\\" + EntryName : EntryName;
-    public string AbsolutePath => ParentDirectory is { } parentDirectory ? parentDirectory.AbsolutePath + "\\" + EntryName : BankFile.AbsolutePath + "\\" + EntryName;
+    public string Path => (ParentDirectory is { } parentDirectory ? parentDirectory.Path + "\\" + EntryName : EntryName).TrimStart('\\');
+    public string AbsolutePath => (ParentDirectory is { } parentDirectory ? parentDirectory.AbsolutePath + "\\" + EntryName : BankFile.AbsolutePath + "\\" + EntryName).TrimStart('\\');
 
 
     public IRVBankDirectory ParentDirectory { get; protected set; }

--- a/test/Scratches/BankTest/Program.cs
+++ b/test/Scratches/BankTest/Program.cs
@@ -33,6 +33,5 @@ var bankOptions = new RVBankOptions()
 };
 
 var bank = RVBank.ReadPbo(@"C:\Users\ryann\Downloads\test.pbo", bankOptions, File.Open(@"C:\Users\ryann\Downloads\Ryann\out\out.pbo", FileMode.OpenOrCreate, FileAccess.ReadWrite), NullLogger.Instance);
-
 bank.SynchronizeWithStream(bankOptions);
 Console.WriteLine();

--- a/test/Scratches/BankTest/Program.cs
+++ b/test/Scratches/BankTest/Program.cs
@@ -31,7 +31,13 @@ var bankOptions = new RVBankOptions()
     AsciiLengthTimeout = 510,
     AllowEncrypted = true
 };
-
-var bank = RVBank.ReadPbo(@"C:\Users\ryann\Downloads\Ryann\HDSN_BreachingCharge.pbo", bankOptions, File.Open(@"C:\Users\ryann\Downloads\Ryann\out\out.pbo", FileMode.OpenOrCreate, FileAccess.ReadWrite), NullLogger.Instance);
+var output = @"C:\Users\ryann\Downloads\Ryann\out\out.pbo";
+File.Delete(output);
+var outStream = File.Open(output, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+var bank = RVBank.ReadPbo(@"C:\Users\ryann\Downloads\Ryann\HDSN_BreachingCharge.pbo", bankOptions, outStream, NullLogger.Instance);
 bank.SynchronizeWithStream(bankOptions);
+outStream.Close();
 Console.WriteLine();
+
+var outBank = RVBank.ReadPbo(output, bankOptions, null, NullLogger.Instance);
+

--- a/test/Scratches/BankTest/Program.cs
+++ b/test/Scratches/BankTest/Program.cs
@@ -32,6 +32,6 @@ var bankOptions = new RVBankOptions()
     AllowEncrypted = true
 };
 
-var bank = RVBank.ReadPbo(@"C:\Users\ryann\Downloads\test.pbo", bankOptions, File.Open(@"C:\Users\ryann\Downloads\Ryann\out\out.pbo", FileMode.OpenOrCreate, FileAccess.ReadWrite), NullLogger.Instance);
+var bank = RVBank.ReadPbo(@"C:\Users\ryann\Downloads\Ryann\HDSN_BreachingCharge.pbo", bankOptions, File.Open(@"C:\Users\ryann\Downloads\Ryann\out\out.pbo", FileMode.OpenOrCreate, FileAccess.ReadWrite), NullLogger.Instance);
 bank.SynchronizeWithStream(bankOptions);
 Console.WriteLine();


### PR DESCRIPTION
With this commit alot of big changes to internal method logic has been changed. Some of these changes have been done half-haphazardly out of pure frustration/confusion, but as of now I **think** I have everything squared out. This PR will start off as a draft as with most of my pulls, but I plan on getting this nice and spiffy by the days end. 

- Bug fixed where `RVBankDirectory::CalculateLength` returned zero resulting in an invalid header length while writing the bank; `CalculateLength` now correctly returns the total length of all its children combined.
- Bug fixed where 'BisBinaryWriter::WriteAsciiZ` confusingly messed up on encoding strings, method was tweaked until a valid result was given.
- Bug fixed in `RVBankDirectoryExtensions`  where previously deleted/moved folders leave behind an empty directory structure.
- Bug fixed in `RVBank::Binarize` where null byte was not written before calculating checksum.
- Add previously missed 21 byte seperator in `RVBank::Binarize`.
- Bug fixed where the `EntryName` would get binarized as opposed to `Path`.